### PR TITLE
Implement Margo's fix + ddg.display.dgg() -> ddg.display()

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,7 +2,7 @@ export(ddg.function, ddg.procedure, ddg.start, ddg.finish, ddg.return.value, ddg
 export(ddg.data, ddg.exception, ddg.url, ddg.file)
 export(ddg.data.in, ddg.data.out, ddg.exception.out, ddg.url.out, ddg.file.out, ddg.graphic.out)
 export(ddg.init, ddg.run, ddg.save, ddg.console.on, ddg.console.off, ddg.annotate.on, ddg.annotate.off)
-export(ddg.debug.lib.on, ddg.debug.lib.off, ddg.display.ddg)
+export(ddg.debug.lib.on, ddg.debug.lib.off, ddg.display)
 export(ddg.breakpoint, ddg.set.breakpoint, ddg.list.breakpoints, ddg.clear.breakpoints)
 export(ddg.flush.ddg)
 export(ddg.source)

--- a/R/RDataTracker.R
+++ b/R/RDataTracker.R
@@ -5639,7 +5639,11 @@ ddg.run <- function(r.script.path = NULL, ddgdir = NULL, overwrite = TRUE, f = N
 	index<- min(which(check.library.paths == TRUE))
 	ddgexplorer_path<- paste(.libPaths()[index],jar.path,sep = "")
 	ddgtxt.path<- paste(ddg.folder,"/ddg.txt",sep = "")
-	system(paste("java -jar ",ddgexplorer_path, ddgtxt.path,'&',sep = " "))
+	if(Sys.info()['sysname']=="Windows"){
+		system(paste("java -jar ",ddgexplorer_path, ddgtxt.path,'&',sep = " "))
+	}else{
+		system(paste("START java -jar ",ddgexplorer_path, ddgtxt.path,sep = " "))
+	}
 }
 
 # This function takes a Rmd file and extracts the R code and text through

--- a/R/RDataTracker.R
+++ b/R/RDataTracker.R
@@ -5639,7 +5639,7 @@ ddg.run <- function(r.script.path = NULL, ddgdir = NULL, overwrite = TRUE, f = N
 	index<- min(which(check.library.paths == TRUE))
 	ddgexplorer_path<- paste(.libPaths()[index],jar.path,sep = "")
 	ddgtxt.path<- paste(ddg.folder,"/ddg.txt",sep = "")
-	if(Sys.info()['sysname']=="Windows"){
+	if(Sys.info()['sysname']!="Windows"){
 		system(paste("java -jar ",ddgexplorer_path, ddgtxt.path,'&',sep = " "))
 	}else{
 		system(paste("START java -jar ",ddgexplorer_path, ddgtxt.path,sep = " "))

--- a/R/RDataTracker.R
+++ b/R/RDataTracker.R
@@ -6085,7 +6085,7 @@ ddg.source <- function (file,  ddgdir = NULL, local = FALSE, echo = verbose, pri
 
 # ddg.display.ddg loads & displays the current DDG.
 
-ddg.display.ddg <- function () {
+ddg.display <- function () {
   if (.ddg.is.set("ddg.path") & file.exists(paste(.ddg.path(), "/ddg.txt", sep=""))) {
     .ddg.loadDDG(.ddg.path())
   } else {

--- a/R/RDataTracker.R
+++ b/R/RDataTracker.R
@@ -5639,7 +5639,7 @@ ddg.run <- function(r.script.path = NULL, ddgdir = NULL, overwrite = TRUE, f = N
 	index<- min(which(check.library.paths == TRUE))
 	ddgexplorer_path<- paste(.libPaths()[index],jar.path,sep = "")
 	ddgtxt.path<- paste(ddg.folder,"/ddg.txt",sep = "")
-	system(paste("java -jar ",ddgexplorer_path, ddgtxt.path,sep = " "))
+	system(paste("java -jar ",ddgexplorer_path, ddgtxt.path,sep = " &"))
 }
 
 # This function takes a Rmd file and extracts the R code and text through

--- a/R/RDataTracker.R
+++ b/R/RDataTracker.R
@@ -5639,7 +5639,7 @@ ddg.run <- function(r.script.path = NULL, ddgdir = NULL, overwrite = TRUE, f = N
 	index<- min(which(check.library.paths == TRUE))
 	ddgexplorer_path<- paste(.libPaths()[index],jar.path,sep = "")
 	ddgtxt.path<- paste(ddg.folder,"/ddg.txt",sep = "")
-	system(paste("java -jar ",ddgexplorer_path, ddgtxt.path,sep = " &"))
+	system(paste("java -jar ",ddgexplorer_path, ddgtxt.path,'&',sep = " "))
 }
 
 # This function takes a Rmd file and extracts the R code and text through

--- a/R/RDataTracker.R
+++ b/R/RDataTracker.R
@@ -559,7 +559,9 @@ ddg.MAX_HIST_LINES <- 2^14
 .ddg.json.environ <- function() {
   # add environment entities
   environ <- ""
-  environ <- paste(environ, "\n\"rdt:environment\" : {\n", sep="")
+  environ <- paste(environ, "\n\"environment\" : {\n", sep="")
+
+  environ <- paste(environ, .ddg.json.nv("rdt:name", "environment"), sep="")
 
   architecture <- R.Version()$arch
   environ <- paste(environ, .ddg.json.nv("rdt:architecture", architecture), sep="")


### PR DESCRIPTION
- ddg.display.ddg() is now simply ddg.display();
- starting DDG-Explorer does not block the use of RStudio anymore (user can go back and forth);

<!---
@huboard:{"order":142.0,"milestone_order":142,"custom_state":""}
-->
