### PR TITLE
Fixes #165

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -14,3 +14,9 @@ importFrom(stringr, str_trim)
 importFrom(devtools, session_info)
 importFrom(methods, setMethod)
 importFrom(methods, setClass)
+importFrom("grDevices", "dev.copy", "dev.copy2pdf", "dev.cur",
+           "dev.list", "dev.off", "dev.print", "dev.set", "pdf")
+importFrom("methods", "new")
+importFrom("utils", "capture.output", "getParseData", "head",
+           "object.size", "packageVersion", "savehistory", "tail",
+           "timestamp", "write.csv")

--- a/R/RDataTracker.R
+++ b/R/RDataTracker.R
@@ -2590,7 +2590,7 @@ ddg.MAX_HIST_LINES <- 2^14
       cmds <- vector("list", (length(exprs)))
       for (i in 1:length(exprs)) {
         expr <- as.expression(exprs[i])
-        cmds[i] <- .ddg.construct.DDGStatement(expr, NA, script.name, script.num, NA,
+        cmds[[i]] <- .ddg.construct.DDGStatement(expr, NA, script.name, script.num, NA,
             annotate.functions, parseData)
       }
       return(cmds)
@@ -2626,7 +2626,7 @@ ddg.MAX_HIST_LINES <- 2^14
     expr <- as.expression(exprs[i])
     next.expr.pos <- new (Class = "DDGStatementPos", 
         non.comment.parse.data[next.parseData, ])
-    cmds[next.cmd] <- .ddg.construct.DDGStatement(expr, next.expr.pos, script.name, script.num, breakpoints,
+    cmds[[next.cmd]] <- .ddg.construct.DDGStatement(expr, next.expr.pos, script.name, script.num, breakpoints,
         annotate.functions, parseData)
     next.cmd <- next.cmd + 1
     

--- a/test-no-instrumentation.xml
+++ b/test-no-instrumentation.xml
@@ -58,7 +58,6 @@
 - CalculateSquareRoot
 - DailySolarRadiation
 - HFDatasetPreview
-- SivanSamplingSmaller
 
   The target "test-all" will do all of the normal & script tests above and
   also Aaron's Simes script, which takes longer to run.
@@ -66,6 +65,10 @@
   Currently SivanSampling is not included in the tests because it produces a DDG
   that is too big.  We need to exclude collecting data on the simple getter functions
   at least.
+  
+  SivanSamplingSmaller was removed from testing with the release of R 3.3.1 since the 
+  script no longer works even without RDataTracker since they have changes how lists of S4 objects
+  are implemented.
 
   To add a new test case, duplicate one of the existing test and update tasks,
   modify the name of the task and the value passed to run-no-instrumentation-test
@@ -622,7 +625,7 @@
 	 	</antcall>
 	</target>
 
-    <target name="script-tests" depends="CalculateSquareRoot, DailySolarRadiation, HFDatasetPreview, SivanSamplingSmaller">
+    <target name="script-tests" depends="CalculateSquareRoot, DailySolarRadiation, HFDatasetPreview">
 	    <echo>Script tests for which out put should not differ </echo>
 	</target>
 	<!--########################## End Script Tests ##########################-->


### PR DESCRIPTION
Changed the syntax used to put an S4 object into a list to avoid the error described in issue 165.

Updated NAMESPACE since R now expects explicit import statements for items used from base packages.

Also, removed SivanSamplingSmaller from the tests that are run with test-all.  The script itself no longer runs even without RDataTracker because of the way that it uses lists of S4 objects.

