### PR TITLE
Fixed RStudio on Windows crashing problem

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -14,9 +14,14 @@ importFrom(stringr, str_trim)
 importFrom(devtools, session_info)
 importFrom(methods, setMethod)
 importFrom(methods, setClass)
-importFrom("grDevices", "dev.copy", "dev.copy2pdf", "dev.cur",
-           "dev.list", "dev.off", "dev.print", "dev.set", "pdf")
-importFrom("methods", "new")
-importFrom("utils", "capture.output", "getParseData", "head",
-           "object.size", "packageVersion", "savehistory", "tail",
-           "timestamp", "write.csv")
+
+# CRAN check gives errors if these are not included.
+# However, if we include these, ddg.run crashes R when run 
+# in RStudio on Windows.  It does not crash on Mac.  It 
+# also does not crash on Windows using the standard R environment.
+#importFrom("grDevices", "dev.copy", "dev.copy2pdf", "dev.cur",
+#           "dev.list", "dev.off", "dev.print", "dev.set", "pdf")
+#importFrom("methods", "new")
+#importFrom("utils", "capture.output", "getParseData", "head",
+#           "object.size", "packageVersion", "savehistory", "tail",
+#           "timestamp", "write.csv")


### PR DESCRIPTION
Commented out the importFrom lines that cause RStudio on Windows to
crash.  Leaving out these lines result in a note when we run cran check,
but leaving them in causes R to crash inside RStudio on Windows.

This is issue 116 again.  I recently added these importFrom lines after running cran check, forgetting about this bug.  Now, I kept the lines in NAMESPACE but they are commented out with an explanation of the bug.