### PR TITLE
Fixed Double Arrow issue with incorrect scoping

### DIFF
--- a/R/RDataTracker.R
+++ b/R/RDataTracker.R
@@ -4497,9 +4497,9 @@ ddg.return.value <- function (expr=NULL, cmd.func=NULL) {
     if (var != "") {
       # Create output data node.
       dvalue <- eval(as.symbol(var), envir=env)
-  
+
       # Check for non-local assignment
-      if ( .ddg.is.nonlocal.assign(return.stmt@parsed) )
+      if ( .ddg.is.nonlocal.assign(return.stmt@parsed[[1]]) )
       {
       	env <- .ddg.where( var, parent.env(parent.frame()) )
 

--- a/R/RDataTracker.R
+++ b/R/RDataTracker.R
@@ -47,12 +47,7 @@ ddg.MAX_HIST_LINES <- 2^14
 
 .ddg.set <- function(var, value) {
   .ddg.env[[var]] <- value
-  #return(invisible(.ddg.env[[var]]))
-  if( var == "ddg.data.nodes" )
-  {
-    print(paste("variable:",var,", value:",value))
-  }
-  return(.ddg.env[[var]])
+  return(invisible(.ddg.env[[var]]))
 }
 
 .ddg.is.set <- function(var) {

--- a/R/RDataTracker.R
+++ b/R/RDataTracker.R
@@ -47,7 +47,9 @@ ddg.MAX_HIST_LINES <- 2^14
 
 .ddg.set <- function(var, value) {
   .ddg.env[[var]] <- value
-  return(invisible(.ddg.env[[var]]))
+  #return(invisible(.ddg.env[[var]]))
+  print(paste("variable:",var,", value:",value))
+  return(.ddg.env[[var]])
 }
 
 .ddg.is.set <- function(var) {

--- a/R/RDataTracker.R
+++ b/R/RDataTracker.R
@@ -90,12 +90,8 @@ ddg.MAX_HIST_LINES <- 2^14
   return (.ddg.get("ddg.path"))
 }
 
-.ddg.data.dir <- function() {
-  return ("data")
-}
-
 .ddg.path.data <- function() {
-  return(paste(.ddg.path(), .ddg.data.dir() , sep="/"))
+  return(paste(.ddg.path(), "/data", sep=""))
 }
 
 .ddg.path.debug <- function() {
@@ -450,13 +446,13 @@ ddg.MAX_HIST_LINES <- 2^14
 
   # Table of sourced scripts
   .ddg.set(".ddg.sourced.scripts", NULL)
-
+  
   # Table of script, line & parsed command numbers
   .ddg.set(".ddg.source.parsed", NULL)
 
   # Save debug files on debug directory
   .ddg.set("ddg.save.debug", FALSE)
-
+  
 }
 
 # .ddg.set.history provides a wrapper to change the number of
@@ -476,7 +472,7 @@ ddg.MAX_HIST_LINES <- 2^14
   dir.create(.ddg.path.data(), showWarnings=FALSE)
   dir.create(.ddg.path.debug(), showWarnings=FALSE)
   dir.create(.ddg.path.scripts(), showWarnings=FALSE)
-
+  
   if (interactive() && .ddg.enable.console()) {
     .ddg.set('ddg.original.hist.size', Sys.getenv('R_HISTSIZE'))
     .ddg.set.history()
@@ -533,14 +529,14 @@ ddg.MAX_HIST_LINES <- 2^14
     ss <- ss[ss$snum > 0, ]
     stimes <- file.info(ss$sname)$mtime
     stimes <- .ddg.format.time(stimes)
-
-    scriptarray <- paste("\t{\"number\" : \"", ss[ , 1], "\",
+    
+    scriptarray <- paste("\t{\"number\" : \"", ss[ , 1], "\", 
                              \"name\" : \"",ss[ , 2], "\",
                              \"timestamp\" : \"",stimes, "\"}",
                          sep = "", collapse =",\n")
     output <- paste("[\n", scriptarray, " ],\n", sep = "")
   }
-  return(output)
+  return(output)  
 }
 
 # ddg.installedpackages() returns information on packages installed at the time of execution
@@ -678,11 +674,7 @@ ddg.MAX_HIST_LINES <- 2^14
 
   environ <- paste(environ, .ddg.json.nv("rdt:script", ddg.r.script.path), sep="")
 
-  if(sourced.scripts==""){
-    environ <- paste(environ, .ddg.json.nv("rdt:sourcedScripts", sourced.scripts), sep="")
-  }else{
-    environ <- paste(environ, "\"rdt:sourcedScripts\" : ", sourced.scripts, ",\n", sep="")
-  }
+  environ <- paste(environ, "\"rdt:sourcedScripts\" : ", sourced.scripts, sep="")
 
   environ <- paste(environ, .ddg.json.nv("rdt:scriptTimeStamp", script.timestamp), sep="")
 
@@ -710,21 +702,21 @@ ddg.MAX_HIST_LINES <- 2^14
 .ddg.json.procedure.node <- function(id, pname, ptype, ptime, snum, pos) {
 
   if (is.object(pos)) {
-    jstr <- paste("\n\"p", id, "\" : {\n\"rdt:name\" : \"", pname, "\",\n\"rdt:type\" : \"", ptype,
-        "\",\n\"rdt:elapsedTime\" : \"", ptime, "\",\n\"rdt:scriptNum\" : \"", snum,
-        "\",\n\"rdt:startLine\" : \"", pos@startLine, "\"",
-        ",\n\"rdt:startCol\" : \"", pos@startCol, "\"",
-        ",\n\"rdt:endLine\" : \"", pos@endLine, "\"",
-        ",\n\"rdt:endCol\" : \"", pos@endCol, "\"",
+    jstr <- paste("\n\"p", id, "\" : {\n\"rdt:name\" : \"", pname, "\",\n\"rdt:type\" : \"", ptype, 
+        "\",\n\"rdt:elapsedTime\" : \"", ptime, "\",\n\"rdt:scriptNum\" : \"", snum, 
+        "\",\n\"rdt:startLine\" : \"", pos@startLine, "\"", 
+        ",\n\"rdt:startCol\" : \"", pos@startCol, "\"", 
+        ",\n\"rdt:endLine\" : \"", pos@endLine, "\"", 
+        ",\n\"rdt:endCol\" : \"", pos@endCol, "\"", 
         "\n}", sep="")
   }
   else {
-    jstr <- paste("\n\"p", id, "\" : {\n\"rdt:name\" : \"", pname, "\",\n\"rdt:type\" : \"", ptype,
-        "\",\n\"rdt:elapsedTime\" : \"", ptime, "\",\n\"rdt:scriptNum\" : \"", snum,
-        "\",\n\"rdt:startLine\" : \"NA\"",
-        ",\n\"rdt:startCol\" : \"NA\"",
-        ",\n\"rdt:endLine\" : \"NA\"",
-        ",\n\"rdt:endCol\" : \"NA\"",
+    jstr <- paste("\n\"p", id, "\" : {\n\"rdt:name\" : \"", pname, "\",\n\"rdt:type\" : \"", ptype, 
+        "\",\n\"rdt:elapsedTime\" : \"", ptime, "\",\n\"rdt:scriptNum\" : \"", snum, 
+        "\",\n\"rdt:startLine\" : \"NA\"", 
+        ",\n\"rdt:startCol\" : \"NA\"", 
+        ",\n\"rdt:endLine\" : \"NA\"", 
+        ",\n\"rdt:endCol\" : \"NA\"", 
         "\n}", sep="")
   }
 
@@ -810,16 +802,16 @@ ddg.MAX_HIST_LINES <- 2^14
   } else value.str <- ""
 
   if (is.object(pos)) {
-    dtxt <- paste(ptype, " p", ddg.pnum, " \"", ddg.pnum, "-", pname, "\"", value.str, " Time=\"", ptime ,
+    dtxt <- paste(ptype, " p", ddg.pnum, " \"", ddg.pnum, "-", pname, "\"", value.str, " Time=\"", ptime , 
         "\" Script=\"", snum, "\"", " Pos=\"", pos@startLine, ",", pos@startCol, ",", pos@endLine, ",", pos@endCol, "\";\n", sep="")
     #print(".ddg.output.procedure.node: dtxt =")
     #print(dtxt)
   }
   else {
-    dtxt <- paste(ptype, " p", ddg.pnum, " \"", ddg.pnum, "-", pname, "\"", value.str, " Time=\"", ptime ,
+    dtxt <- paste(ptype, " p", ddg.pnum, " \"", ddg.pnum, "-", pname, "\"", value.str, " Time=\"", ptime , 
         "\" Script=\"", snum, "\"", " Pos=\"NA\";\n", sep="")
   }
-
+  
   # Record in ddg.txt
   .ddg.append(dtxt)
 
@@ -1203,7 +1195,7 @@ ddg.MAX_HIST_LINES <- 2^14
   ddg.proc.nodes$ddg.value[ddg.pnum] <- pvalue
   ddg.proc.nodes$ddg.auto.created[ddg.pnum] <- auto.created
   ddg.proc.nodes$ddg.time[ddg.pnum] <- ptime
-
+  
   ddg.proc.nodes$ddg.snum[ddg.pnum] <- snum
   if (is.object(pos) && length(pos@startLine == 1)) {
     ddg.proc.nodes$ddg.startLine[ddg.pnum] <- pos@startLine
@@ -1217,7 +1209,7 @@ ddg.MAX_HIST_LINES <- 2^14
     ddg.proc.nodes$ddg.endLine[ddg.pnum] <- NA
     ddg.proc.nodes$ddg.endCol[ddg.pnum] <- NA
   }
-
+  
   .ddg.set("ddg.proc.nodes", ddg.proc.nodes)
 
   # Output procedure node.
@@ -1264,7 +1256,7 @@ ddg.MAX_HIST_LINES <- 2^14
   if (length(dvalue) > 1 || !is.atomic(dvalue)) dvalue2 <- "complex"
   else if (!is.null(dvalue)) dvalue2 <- dvalue
   else dvalue2 <- ""
-
+  
   #print(".ddg.record.data: adding info")
   ddg.data.nodes$ddg.type[ddg.dnum] <- dtype
   ddg.data.nodes$ddg.num[ddg.dnum] <- ddg.dnum
@@ -1615,16 +1607,13 @@ ddg.MAX_HIST_LINES <- 2^14
   }
 }
 
-# .ddg.is.global.assign returns TRUE if the object passed is an
-# expression object containing a global assignment.
+# .ddg.is.nonlocal.assign returns TRUE if the object passed is an
+# expression object containing a non-local assignment.
 
 # expr - input expression.
 
-.ddg.is.global.assign <- function (expr) {
-  # This is not really right!  <<- does not necessarily mean it is global
-  # It uses the scope in which the function was declared, so if this is
-  # used inside a function that is returned by another function, it will
-  # not necessarily mean it is global.
+.ddg.is.nonlocal.assign <- function (expr) {
+  # <<- or ->> means that the assignment is non-local
   if (is.call(expr)) {
     # This also finds uses of ->>.
     if (identical(expr[[1]], as.name("<<-")))
@@ -1701,7 +1690,7 @@ ddg.MAX_HIST_LINES <- 2^14
 
 .ddg.add.to.vars.set <- function(vars.set, cmd, i) {
   #print("In .ddg.add.to.vars.set")
-
+  
   # Find out the variable being assigned to by a simple assignment
   # statement.
   main.var.assigned <- cmd@vars.set
@@ -1825,7 +1814,7 @@ ddg.MAX_HIST_LINES <- 2^14
   # Find all the variables used in this command.
   #print (paste(".ddg.create.data.use.edges.for.console.cmd: cmd = ", cmd@text))
   vars.used <- cmd@vars.used
-
+  
   for (var in vars.used) {
     #print(paste(".ddg.create.data.use.edges.for.console.cmd: var =", var))
     # Make sure there is a node we could connect to.
@@ -1903,14 +1892,14 @@ ddg.MAX_HIST_LINES <- 2^14
             eval (parse(text=var), parent.env(env))
           }
         )
-
+      
 			  tryCatch(.ddg.save.data(var, val, fname=".ddg.create.data.set.edges.for.cmd", error=TRUE, scope=scope, stack=stack, env=env),
 			         error = function(e){.ddg.data.node("Data", var, "complex", scope)})
 
         .ddg.proc2data(cmd@abbrev, var, scope)
     }
   }
-
+  
 }
 
 # .ddg.create.data.node.for.possible.writes creates a data node for
@@ -1943,7 +1932,7 @@ ddg.MAX_HIST_LINES <- 2^14
     }
   }
   #print("Done with .ddg.create.data.node.for.possible.writes")
-
+  
 }
 
 # Given a parse tree, this function returns a list containing
@@ -2225,14 +2214,14 @@ ddg.MAX_HIST_LINES <- 2^14
     file <- paste0("dev.off.", .ddg.dnum()+1, ".pdf")
   }
   #print(paste(".ddg.capture.graphics: writing to ", file))
-
+  
   # Save the graphic to a file temporarily
   #print(sys.calls())
   dev.print(device=pdf, file=file)
-
+  
   # Add it to the ddg.  This will copy the file to the right directory
   ddg.file.out (file, pname=cmd@abbrev)
-
+  
   # Remove the temporary file
   file.remove(file)
 }
@@ -2387,7 +2376,7 @@ ddg.MAX_HIST_LINES <- 2^14
   if (.ddg.debug.lib()) print(paste(called, ":  Adding", node.name,  type, "node"))
   .ddg.proc.node(type, node.name, node.name, TRUE, env=env, cmd = cmd)
   .ddg.proc2proc()
-
+  
   return(node.name)
 }
 
@@ -2531,7 +2520,7 @@ ddg.MAX_HIST_LINES <- 2^14
   if (!.ddg.get("ddg.break")) {
     writeLines("\nEnter = next command, C = next breakpoint, D = display DDG, Q = quit debugging\n")
   }
-
+  
   # Abbreviate command.
   abbrev <- command@abbrev
 
@@ -2558,7 +2547,7 @@ ddg.MAX_HIST_LINES <- 2^14
 
     print(paste("[", func.name, "]  |  ", abbrev, sep=""))
   }
-
+  
   # Save ddg.
   .ddg.txt.write()
   .ddg.json.write()
@@ -2567,19 +2556,19 @@ ddg.MAX_HIST_LINES <- 2^14
   line <- "D"
   while (line == "D") {
     line <- toupper(readline())
-    if (line == "D") ddg.display()
+    if (line == "D") .ddg.loadDDG(.ddg.path())
     else if (line == "") .ddg.set("ddg.break", TRUE)
     else if (line == "C") .ddg.set("ddg.break", FALSE)
     else if (line == "Q") .ddg.set("ddg.break.ignore", TRUE)
   }
-
+  
 }
 
 # Create the DDGStatement list for a list of parsed expressions.
 
 # exprs - a list of parsed expressions
 # script.name - the name of the script the expressions come from
-# annotate.functions - if true, we will place annotations inside function defintions so we can record
+# annotate.functions - if true, we will place annotations inside function defintions so we can record 
 #      provenance internal to them
 # parseData - information provided by the parser that we use to find line numbers
 # enclosing.pos - if exprs are statements within a function definition, enclosing.pos is the source position
@@ -2588,11 +2577,11 @@ ddg.MAX_HIST_LINES <- 2^14
 # Returns a list of DDGStatement objects
 
 .ddg.create.DDGStatements <- function (exprs, script.name, script.num, annotate.functions, parseData = NULL, enclosing.pos = NULL) {
-
+  
   # The parse data gives us line number information
   if (is.null(parseData)) {
     parseData <- getParseData(exprs, includeText=TRUE)
-
+    
     if (is.null(parseData)) {
       # In this case there is no line number information available
       cmds <- vector("list", (length(exprs)))
@@ -2608,50 +2597,50 @@ ddg.MAX_HIST_LINES <- 2^14
     if (nrow(non.comment.parse.data) == 0) {
       return(list())
     }
-
+    
     # Start at the first non-comment expression in parseData
     next.parseData <- 1
   }
-
+  
   else {
     non.comment.parse.data <- parseData[parseData$token != "COMMENT", ]
-
+    
     # Start at the first entry in parse data that begins after the enclosing function begins,
     # ends before the enclosing function ends, and matches the text of the first expression.
     next.parseData <- which(non.comment.parse.data$line1 >= enclosing.pos@startLine &
-            non.comment.parse.data$line2 <= enclosing.pos@endLine &
+            non.comment.parse.data$line2 <= enclosing.pos@endLine & 
             non.comment.parse.data$text == paste(deparse(exprs[[1]]), collapse="\n") )[1]
   }
-
+  
   # Get the breakpoint information
   breakpoints <- ddg.list.breakpoints()
   breakpoints <- breakpoints[breakpoints$sname == script.name, ]
-
+  
   # Create the DDGStatements
   cmds <- vector("list", (length(exprs)))
   next.cmd <- 1
   for (i in 1:length(exprs)) {
     expr <- as.expression(exprs[i])
-    next.expr.pos <- new (Class = "DDGStatementPos",
+    next.expr.pos <- new (Class = "DDGStatementPos", 
         non.comment.parse.data[next.parseData, ])
     cmds[[next.cmd]] <- .ddg.construct.DDGStatement(expr, next.expr.pos, script.name, script.num, breakpoints,
         annotate.functions, parseData)
     next.cmd <- next.cmd + 1
-
+    
     # If there are more expressions, determine where to look next in the parseData
     if (i < length(exprs)) {
        last.ending.line <- non.comment.parse.data[next.parseData,]$line2
        last.parent <- non.comment.parse.data[next.parseData,"parent"]
        last.id <- non.comment.parse.data[next.parseData,"id"]
-
-       # Find the first entry in parseData that has the same parent as the
+       
+       # Find the first entry in parseData that has the same parent as the 
        # previous expression and starts after the previous expression.
-       next.parseData <- which(non.comment.parse.data$parent == last.parent &
+       next.parseData <- which(non.comment.parse.data$parent == last.parent & 
                non.comment.parse.data$line1 >= last.ending.line &
                non.comment.parse.data$id > last.id) [1]
     }
   }
-
+  
   return (cmds)
 }
 
@@ -2683,7 +2672,7 @@ ddg.MAX_HIST_LINES <- 2^14
 # ddg.annotate.on and ddg.annotate.off may be used to limit the
 # functions that are annotated or not annotated, respectively.
 #
-# If run.commands is false, the commands are not executed.  This allows
+# If run.commands is false, the commands are not executed.  This allows 
 # us to build ddgs for commands run from the console as those commands
 # have already been executed.
 
@@ -2705,14 +2694,14 @@ ddg.MAX_HIST_LINES <- 2^14
 #   output for deparse of a single expression.
 # annotate.functions (optional) - if TRUE, functions are annotated
 # called.from.ddg.eval(optional) - whether called from ddg.eval
-# cmds - list of DDG Statements that correspond to the exprs passed in.  This is
+# cmds - list of DDG Statements that correspond to the exprs passed in.  This is 
 #   currently only used when called from ddg.eval.  Normally, ddg.parse.commands
 #   creates the DDG Statement objects.
 
-.ddg.parse.commands <- function (exprs, script.name="", script.num=NA, environ, ignore.patterns=c('^ddg.'),
-    node.name="Console", run.commands = FALSE, echo=FALSE, print.eval=echo, max.deparse.length=150,
+.ddg.parse.commands <- function (exprs, script.name="", script.num=NA, environ, ignore.patterns=c('^ddg.'), 
+    node.name="Console", run.commands = FALSE, echo=FALSE, print.eval=echo, max.deparse.length=150, 
     annotate.functions = FALSE, called.from.ddg.eval=FALSE, cmds=NULL) {
-
+  
   # Gather all the information that we need about the statements
   if (is.null(cmds)) {
     cmds <- .ddg.create.DDGStatements (exprs, script.name, script.num, annotate.functions)
@@ -2722,17 +2711,17 @@ ddg.MAX_HIST_LINES <- 2^14
     }
   }
   num.cmds <- length(cmds)
-
+  
   # Figure out if we will execute commands or not.
   execute <- run.commands & !is.null(environ) & is.environment(environ)
-
+  
   #print (paste("ddg.parse.commands: .ddg.func.depth =", .ddg.get(".ddg.func.depth")))
   inside.func <- (.ddg.get(".ddg.func.depth") > 0)
-
+  
   # Attempt to close the previous collapsible command node if a ddg
   # exists
   if (.ddg.is.init() && !inside.func) .ddg.close.last.command.node(environ, initial=TRUE)
-
+  
   # Get the last command in the new commands and check to see if
   # we need to create a new .ddg.last.cmd node for future reference.
   if (!inside.func) {
@@ -2742,12 +2731,12 @@ ddg.MAX_HIST_LINES <- 2^14
       .ddg.last.cmd <- NULL
       #print(".ddg.parse.commands: setting .ddg.last.cmd to null")
     }
-
+    
     else if (!execute) {
       cmds <- cmds[1:num.cmds-1]
     }
   }
-
+  
   # Create start and end nodes to allow collapsing of consecutive
   # console nodes. Don't bother doing this if there is only 1 new
   # command in the history or execution.
@@ -2760,11 +2749,11 @@ ddg.MAX_HIST_LINES <- 2^14
     named.node.set <- TRUE
     start.node.created <- node.name
   }
-
+  
   # Don't set .ddg.last.cmd.  We want it to have the value from
   # the last call. We set it at the end of this function:
   # .ddg.set(".ddg.last.cmd", .ddg.last.cmd)
-
+  
   # Create an operation node for each command.  We can't use lapply
   # here because we need to process the commands in order and
   # lapply does not guarantee an order. Also decide which data nodes
@@ -2775,10 +2764,10 @@ ddg.MAX_HIST_LINES <- 2^14
   # the last writer/possible writer. Lastly, if environ is set to
   # true, then execute each command immediately before attempting
   # to create the DDG nodes.
-
+  
   # Only go through this if  we have at least one command to parse.
   if (num.cmds > 0) {
-
+    
     # Find where all the variables are assigned for non-environ
     # files.
     if (!execute) {
@@ -2792,34 +2781,44 @@ ddg.MAX_HIST_LINES <- 2^14
     for (i in 1:length(cmds)) {
       cmd <- cmds[[i]]
       if (.ddg.debug.lib()) print(paste(".ddg.parse.commands: Processing", cmd@abbrev))
-
+      
       # Process breakpoint. We stop if there is a breakpoint set on this line or we are single-stepping.
       #print("Checking for breakpoints")
       if (.ddg.is.sourced() & (cmd@is.breakpoint | .ddg.get("ddg.break")) & !.ddg.break.ignore()) {
         .ddg.process.breakpoint(cmd, inside.function=called.from.ddg.eval)
       }
-
+      
       #print("Checking whether to set last.cmd")
       if (.ddg.enable.source() && grepl("^ddg.eval", cmd@text) && .ddg.enable.console()) {
         if (is.null(.ddg.last.cmd)) {
           .ddg.last.cmd <- cmd
         }
       }
-
+      
       # Get environment for output data node.
       d.environ <- environ
-      if (.ddg.is.global.assign(cmd@parsed[[1]])) d.environ <- globalenv()
+      if ( .ddg.is.nonlocal.assign(cmd@parsed[[1]]) ) 
+      {
+      	for( var in cmd@vars.set)
+      	{
+      		d.environ <- .ddg.where( var , parent.env(parent.frame()) )
 
+      		if( d.environ == "undefined" )
+      		{
+      			d.environ <- globalenv()
+      		}
+      	}
+      }
       # Specifies whether or not a procedure node should be created
       # for this command. Basically, if a ddg exists and the
       # command is not a DDG command, it should be created.
-
+      
       create <- !cmd@isDdgFunc && .ddg.is.init() && .ddg.enable.console()
       start.finish.created <- FALSE
-
+      
       # If the command does not match one of the ignored patterns.
       if (!any(sapply(ignore.patterns, function(pattern){grepl(pattern, cmd@text)}))) {
-
+        
         # If sourcing, we want to execute the command.
         if (execute) {
           # Print command.
@@ -2831,19 +2830,19 @@ ddg.MAX_HIST_LINES <- 2^14
                         else nd), "\n")
             cat(cmd.show)
           }
-
+          
           # If we will create a node, then before execution, set
           # this command as a possible abstraction node but only
           # if it's not a call that itself creates abstract nodes.
           if (!cmd@isDdgFunc) {
             .ddg.set(".ddg.possible.last.cmd", cmd)
             .ddg.set (".ddg.cur.cmd", cmd)
-
+            
             # Remember the current statement on the stack so that we
             # will be able to create a corresponding Finish node later
             # if needed.
             .ddg.cur.cmd.stack <- .ddg.get(".ddg.cur.cmd.stack")
-
+            
             if (length(.ddg.cur.cmd.stack) == 0) {
               .ddg.cur.cmd.stack <- c(cmd, FALSE)
             }
@@ -2852,11 +2851,11 @@ ddg.MAX_HIST_LINES <- 2^14
             }
             .ddg.set(".ddg.cur.cmd.stack", .ddg.cur.cmd.stack)
           }
-
+          
           else if (.ddg.is.procedure.cmd(cmd)) {
             .ddg.set(".ddg.possible.last.cmd", NULL)
           }
-
+          
           # Capture any warnings that occur when an expression is evaluated.
           # Note that we cannot just use a tryCatch here because it behaves slightly differently
           # and we would lose the value that eval returns.  withCallingHandlers returns the value.
@@ -2865,14 +2864,14 @@ ddg.MAX_HIST_LINES <- 2^14
           if (.ddg.debug.lib()) print (paste (".ddg.parse.commands evaluating ", cmd@annotated))
           result <- withCallingHandlers (eval(cmd@annotated, environ, NULL), warning = .ddg.set.warning)
           if (.ddg.debug.lib()) print (paste (".ddg.parse.commands done evaluating ", cmd@annotated))
-
+          
           if (!cmd@isDdgFunc) {
             # Need to get the stack again because it could have been
             # modified during the eval call.
             .ddg.cur.cmd.stack <- .ddg.get(".ddg.cur.cmd.stack")
             stack.length <- length(.ddg.cur.cmd.stack)
             start.created <- .ddg.cur.cmd.stack[stack.length][[1]]
-
+            
             # Create a finish node if a start node was created
             # start.created can have one of 3 values: "TRUE", "FALSE",
             # "MATCHES_CALL". Only create the finish node if TRUE.
@@ -2881,7 +2880,7 @@ ddg.MAX_HIST_LINES <- 2^14
               start.finish.created <- TRUE
               .ddg.link.function.returns(cmd)
             }
-
+            
             # Remove the last command & start.created values pushed
             # onto the stack
             if (stack.length == 2) {
@@ -2891,34 +2890,34 @@ ddg.MAX_HIST_LINES <- 2^14
               .ddg.set(".ddg.cur.cmd.stack", .ddg.cur.cmd.stack[1:(stack.length-2)])
             }
           }
-
+          
           # Print evaluation.
           if (print.eval) print(result)
-
+          
         }
-
+        
         # Figure out if we should create a procedure node for this
         # command. We don't create it if it matches a last command
         # (because that last command has now become a collapsible
         # node). Matching a last command means that the last command
         # is set, is not NULL, and is equal to the current command.
-
+        
         last.proc.node.created <-
             if (.ddg.is.set (".ddg.last.proc.node.created")).ddg.get(".ddg.last.proc.node.created")
             else ""
         cur.cmd.closed <- (last.proc.node.created == paste ("Finish", cmd@abbrev))
         create.procedure <- create && (!cur.cmd.closed || !named.node.set) && !start.finish.created  && !grepl("^ddg.source", cmd@text)
-
+        
         # We want to create a procedure node for this command.
         if (create.procedure) {
-
+          
           # Create the procedure node.
-
+          
           if (.ddg.debug.lib()) print(paste(".ddg.parse.commands: Adding operation node for", cmd@abbrev))
-
+          
           .ddg.proc.node("Operation", cmd@abbrev, cmd@abbrev, env=environ, console=TRUE, cmd=cmd)
           .ddg.proc2proc()
-
+          
           # If a warning occurred when cmd was evaluated,
           # attach a warning node
           if (.ddg.warning.occurred()) {
@@ -2927,7 +2926,7 @@ ddg.MAX_HIST_LINES <- 2^14
           # Store information on the last procedure node in this
           # block.
           last.proc.node <- cmd
-
+          
           # We want to create the incoming data nodes (by updating
           # the vars.set).
           if (execute) {
@@ -2935,15 +2934,15 @@ ddg.MAX_HIST_LINES <- 2^14
             vars.set <- .ddg.add.to.vars.set(vars.set,cmd,i)
             if (.ddg.debug.lib()) print(paste(".ddg.parse.commands: Adding", cmd@abbrev, "information to vars.set"))
           }
-
+          
           .ddg.create.data.use.edges.for.console.cmd(vars.set, cmd, i, for.caller=FALSE)
           if (cmd@readsFile) .ddg.create.file.read.nodes.and.edges(cmd, environ)
           .ddg.link.function.returns(cmd)
-
+          
           if (.ddg.debug.lib()) print(paste(".ddg.parse.commands: Adding input data nodes for", cmd@abbrev))
           .ddg.create.data.set.edges.for.cmd(vars.set, cmd, i, d.environ)
           if (.ddg.debug.lib()) print(paste(".ddg.parse.commands: Adding output data nodes for", cmd@abbrev))
-
+          
           if (cmd@writesFile) .ddg.create.file.write.nodes.and.edges (cmd, environ)
           .ddg.set.graphics.files (cmd, environ)
           if (cmd@has.dev.off) {
@@ -2960,16 +2959,16 @@ ddg.MAX_HIST_LINES <- 2^14
             .ddg.create.data.set.edges.for.cmd(vars.set, cmd, i, environ)
           }
         }
-
+        
         if (create.procedure && execute) {
           .ddg.create.data.node.for.possible.writes(vars.set, last.proc.node, env=environ)
-
+          
           # Update so we don't set these again.
           vars.set$possible.last.writer <- vars.set$last.writer
         }
       }
      }
-
+     
      # Create a data node for each variable that might have been set in
      # something other than a simple assignment, with an edge from the
      # last node in the console block or source .
@@ -2977,31 +2976,31 @@ ddg.MAX_HIST_LINES <- 2^14
        .ddg.create.data.node.for.possible.writes(vars.set, last.proc.node, env=environ)
      }
   }
-
+  
   #print("Done with ddg.parse.commands loop")
-
+    
   # Close any node left open during execution.
   if (execute && !inside.func) .ddg.close.last.command.node(environ, initial=TRUE)
-
+  
   # Close the console block if we processed anything and the DDG
   # is initialized (also, save).
   #
   if (.ddg.is.init() && named.node.set && !inside.func) {
     .ddg.add.abstract.node("Finish", node.name = node.name, env=environ)
   }
-
+  
   # Open up a new collapsible node in case we need to parse
   # further later.
   if (!execute) {
-
+    
     .ddg.set(".ddg.possible.last.cmd", .ddg.last.cmd)
     .ddg.set(".ddg.last.cmd", .ddg.last.cmd)
     .ddg.open.new.command.node(environ)
   }
-
+  
   # Write time stamp to history.
   if (.ddg.is.init() && !.ddg.is.sourced()) .ddg.write.timestamp.to.history()
-
+  
 }
 
 
@@ -3056,8 +3055,8 @@ ddg.MAX_HIST_LINES <- 2^14
 # env - the environment in which the procedure occurs
 
 # CHECK!  Looks like env parameter is not needed!
-.ddg.proc.node <- function(ptype, pname, pvalue="", console=FALSE,
-    auto.created=FALSE, env = sys.frame(.ddg.get.frame.number(sys.calls())),
+.ddg.proc.node <- function(ptype, pname, pvalue="", console=FALSE, 
+    auto.created=FALSE, env = sys.frame(.ddg.get.frame.number(sys.calls())), 
     cmd = NULL) {
   if (.ddg.debug.lib()) {
   	if (length(pname) > 1) {
@@ -3223,13 +3222,13 @@ ddg.MAX_HIST_LINES <- 2^14
         # Replace double quotes with single quotes.
         .ddg.replace.quotes(dvalue)
       }
-
+      
   #print(".ddg.data.node: converted value to string")
-
+      
 
   if (grepl("\n", val)) {
     #print(".ddg.data.node: saving as snapshot")
-
+    
     # Create snapshot node.
     .ddg.snapshot.node (dname, "txt", val, from.env=from.env)
     return
@@ -3237,7 +3236,7 @@ ddg.MAX_HIST_LINES <- 2^14
 
   else {
     #print(".ddg.data.node: recording data")
-
+    
     # Get scope if necessary.
     if (is.null(dscope)) dscope <- .ddg.get.scope(dname)
 
@@ -3435,10 +3434,9 @@ ddg.MAX_HIST_LINES <- 2^14
 	# Add number to file name.
 	dfile <- paste(.ddg.dnum()+1, "-", file.name, sep="")
 
-  # Calculate the path to the file relative to the ddg directory.
-  # This is the value stored in the node.
-  dpfile <- paste(.ddg.data.dir(), dfile, sep="/")
-  
+	# Get path plus file name.
+	dpfile <- paste(.ddg.path.data(), "/", dfile, sep="")
+
 	dtime <- .ddg.timestamp()
 
 	# Set the node label.
@@ -3453,9 +3451,7 @@ ddg.MAX_HIST_LINES <- 2^14
   # Record in data node table
   .ddg.record.data(dtype, dname, dpfile, dscope, from.env=from.env, dtime, file.loc)
 
-  # Get path plus file name to where the file will be copied
-  dpath <- paste(.ddg.path.data(), "/", dfile, sep="")
-  return(dpath)
+  return(dpfile)
 }
 
 # .ddg.file.copy creates a data node of type File. File nodes are
@@ -4030,47 +4026,64 @@ ddg.MAX_HIST_LINES <- 2^14
   }
 }
 
+# .ddg.loadDDG displays the DDG automatically.
+
+.ddg.loadDDG<- function(ddg.folder){
+  jar.path<- "/RDataTracker/java/DDGExplorer.jar"
+  check.library.paths<- file.exists(paste(.libPaths(),jar.path,sep = ""))
+  index<- min(which(check.library.paths == TRUE))
+  ddgexplorer_path<- paste(.libPaths()[index],jar.path,sep = "")
+  ddgtxt.path<- paste(ddg.folder,"/ddg.txt",sep = "")
+  system(paste("java -jar ", ddgexplorer_path, ddgtxt.path, sep = " "), wait = FALSE)
+  
+#   if(Sys.info()['sysname']!="Windows"){
+# 		system(paste("java -jar ",ddgexplorer_path, ddgtxt.path,'&',sep = " "))
+# 	}else{
+# 		system(paste("START java -jar ",ddgexplorer_path, ddgtxt.path,sep = " "))
+# 	}
+}
+
 # .ddg.markdown takes a Rmd file and extracts the R code and text through
 # the purl function in the knitr library. It then annotates the R script
 # to insert start and finish nodes based on the chunks the user already
 # created. If eval = false, then the chunk will not be added to the DDG. If
 # the user has a name for the chunk, then that name will be used, else a chunk
 # name "ddg.chunk_1" and higher numbers will be generated.
-#
+# 
 # Important: If in a code chunk, there is an empty line followed by "# ----"
 # or "#'", then an extra finish node will be inserted, causing an error.
-#
+# 
 # r.script.path is the path of the original Rmd file
 # output.path is the path of the generated R script
 
 .ddg.markdown <- function(r.script.path = NULL, output.path = NULL){
-
+  
   #generates R script file from markdown file
   knitr::purl(r.script.path, documentation = 2L, quiet = TRUE)
-
+  
   #moves file to ddg directory
   file.rename(from = paste(getwd(), "/", basename(tools::file_path_sans_ext(r.script.path)), ".R", sep = ""), to = output.path)
   script <- readLines(output.path)
-
+  
   skip <- FALSE
   name <- "ddg.chunk"
   annotated <- character(0)
   index <- 1
-
-
+  
+  
   # This for loop goes through the script line by line and searches for patterns
   # to insert the start and finish nodes
   for(i in 1:length(script)){
-
+    
     #eval = false means we skip this code chunk, therefore skip = TRUE
     if(regexpr("eval+(\\s*)+=+(\\s*)+FALSE", script[i]) != -1){
       skip <- TRUE
       annotated <- append(annotated, script[i])
     }
-
+    
     else if(regexpr("## ----", script[i]) != -1){
-
-      #if no options in the line, then generate default name.
+      
+      #if no options in the line, then generate default name.      
       if(regexpr("## -----", script[i]) == -1){
         if(regexpr("=", script[i]) == -1){
           end <- regexpr("-----", script[i])
@@ -4092,7 +4105,7 @@ ddg.MAX_HIST_LINES <- 2^14
       name <- stringr::str_trim(name, side = "both")
       annotated <- append(annotated, paste("ddg.start(\"", name, "\")", sep = ""))
     }
-    else if(nchar(script[i]) == 0 && (regexpr("#'", script[i + 1]) != -1 ||
+    else if(nchar(script[i]) == 0 && (regexpr("#'", script[i + 1]) != -1 || 
                                       i == length(script) || regexpr("## ----", script[i + 1]) != -1 )){
       if(skip){
         annotated <- append(annotated, script[i])
@@ -4117,31 +4130,31 @@ ddg.MAX_HIST_LINES <- 2^14
   fileout <- paste(.ddg.path.debug(), "/initial-environment.csv", sep="")
   ddg.initial.env <- .ddg.initial.env()
   write.csv(ddg.initial.env, fileout, row.names=FALSE)
-
+  
   # Save procedure nodes table to file.
   fileout <- paste(.ddg.path.debug(), "/procedure-nodes.csv", sep="")
   ddg.proc.nodes <- .ddg.proc.nodes()
   ddg.proc.nodes <- ddg.proc.nodes[ddg.proc.nodes$ddg.num > 0, ]
   write.csv(ddg.proc.nodes, fileout, row.names=FALSE)
-
+  
   # Save data nodes table to file.
   fileout <- paste(.ddg.path.debug(), "/data-nodes.csv", sep="")
   ddg.data.nodes <- .ddg.data.nodes()
   ddg.data.nodes2 <- ddg.data.nodes[ddg.data.nodes$ddg.num > 0, ]
   write.csv(ddg.data.nodes2, fileout, row.names=FALSE)
-
+  
   # Save edges table to file.
   fileout <- paste(.ddg.path.debug(), "/edges.csv", sep="")
   ddg.edges <- .ddg.edges()
   ddg.edges2 <- ddg.edges[ddg.edges$ddg.num > 0, ]
   write.csv(ddg.edges2, fileout, row.names=FALSE)
-
+  
   # Save function return table to file.
   fileout <- paste(.ddg.path.debug(), "/function-returns.csv", sep="")
   ddg.returns <- .ddg.get(".ddg.return.values")
   ddg.returns2 <- ddg.returns[ddg.returns$return.node.id > 0, ]
   write.csv(ddg.returns2, fileout, row.names=FALSE)
-
+  
   # Save if script is sourced.
   if (.ddg.is.sourced()) {
     # Save sourced script table to file.
@@ -4149,7 +4162,7 @@ ddg.MAX_HIST_LINES <- 2^14
     ddg.sourced.scripts <- .ddg.get(".ddg.sourced.scripts")
     ddg.sourced.scripts2 <- ddg.sourced.scripts[ddg.sourced.scripts$snum >= 0, ]
     write.csv(ddg.sourced.scripts2, fileout, row.names=FALSE)
-
+    
     # Save data object table to file.
     fileout <- paste(.ddg.path.debug(), "/data-objects.csv", sep="")
     ddg.data.objects <- .ddg.data.objects()
@@ -4359,12 +4372,12 @@ ddg.return.value <- function (expr=NULL, cmd.func=NULL) {
 
   # If expr is an assignment, create nodes and edges for the assignment.
   orig.expr <- substitute(expr)
-
+  
   frame.num <- .ddg.get.frame.number(sys.calls())
   env <- sys.frame(frame.num)
 
   orig.return <- paste("return(", deparse(orig.expr), ")", sep="")
-
+  
   pname <- NULL
   .ddg.lookup.function.name(pname)
 
@@ -4430,7 +4443,7 @@ ddg.return.value <- function (expr=NULL, cmd.func=NULL) {
     return.stmt <- cmd.func()
     parsed.statement <- return.stmt@parsed
   }
-
+  
   # Process breakpoint. We stop if there is a breakpoint set on this line or we are single-stepping.
   if (.ddg.is.sourced() & (return.stmt@is.breakpoint | .ddg.get("ddg.break")) & !.ddg.break.ignore()) {
     .ddg.process.breakpoint(return.stmt, inside.function=TRUE)
@@ -4444,7 +4457,7 @@ ddg.return.value <- function (expr=NULL, cmd.func=NULL) {
 
   # Create an edge from the return statement to its return value.
   .ddg.proc2data(return.stmt@abbrev, return.node.name, return.node.scope, return.value=TRUE)
-
+  
   # Update the table.
   ddg.num.returns <- ddg.num.returns + 1
   ddg.return.values$ddg.call[ddg.num.returns] <- call.text
@@ -4452,7 +4465,7 @@ ddg.return.value <- function (expr=NULL, cmd.func=NULL) {
   ddg.return.values$return.node.id[ddg.num.returns] <- .ddg.dnum()
   .ddg.set(".ddg.return.values", ddg.return.values)
   .ddg.set(".ddg.num.returns", ddg.num.returns)
-
+  
   # Create edges from variables used in the return statement
   vars.used <- return.stmt@vars.used
   for (var in vars.used) {
@@ -4467,9 +4480,17 @@ ddg.return.value <- function (expr=NULL, cmd.func=NULL) {
     if (var != "") {
       # Create output data node.
       dvalue <- eval(as.symbol(var), envir=env)
+  
+      # Check for non-local assignment
+      if ( .ddg.is.nonlocal.assign(return.stmt@parsed) )
+      {
+      	env <- .ddg.where( var, parent.env(parent.frame()) )
 
-      # Check for global assignment
-      if (.ddg.is.global.assign(return.stmt@parsed)) env <- globalenv()
+      	if( env == "undefined" )
+      	{
+      		env <- globalenv()
+      	}
+      }
       dscope <- .ddg.get.scope(var, env=env)
       .ddg.save.data(var, dvalue, scope=dscope)
       # Create an edge from procedure node to data node.
@@ -4485,7 +4506,7 @@ ddg.return.value <- function (expr=NULL, cmd.func=NULL) {
   if (return.stmt@has.dev.off) {
     .ddg.capture.graphics(return.stmt)
   }
-
+  
   # Create the finish node for the function
   if (typeof(call[[1]]) == "closure") {
     .ddg.add.abstract.node ("Finish", node.name=pname, env=caller.env)
@@ -4519,7 +4540,7 @@ ddg.eval <- function(statement, cmd.func=NULL) {
     #print(cmd@pos)
   }
   if (.ddg.debug.lib()) print (paste("ddg.eval: statement =", statement))
-
+  
   frame.num <- .ddg.get.frame.number(sys.calls())
   env <- sys.frame(frame.num)
 
@@ -4954,10 +4975,10 @@ ddg.finish <- function(pname=NULL) {
 ddg.init <- function(r.script.path = NULL, ddgdir = NULL, overwrite = TRUE, enable.console = TRUE, max.snapshot.size = 100) {
   #.ddg.DDGStatement.init()
   .ddg.init.tables()
-
-  # Setting the path for the ddg
+  
+  # Setting the path for the ddg    
   if (is.null(ddgdir)) {
-
+    
     # Default is the file where the script is located
     if (!is.null(r.script.path)){
       ddg.path <- paste(dirname(r.script.path), "/", basename(tools::file_path_sans_ext(r.script.path)), "_ddg", sep="")
@@ -4966,8 +4987,8 @@ ddg.init <- function(r.script.path = NULL, ddgdir = NULL, overwrite = TRUE, enab
       ddg.path <- paste(getwd(), "/","ddg",sep = "")
     }
   } else ddg.path <- normalizePath(ddgdir, winslash="/", mustWork=FALSE)
-
-  # Overwrite default is
+  
+  # Overwrite default is 
   if(!overwrite){
     no.overwrite.folder <- paste(ddg.path, "_timestamps", sep = "")
     if(!dir.exists(no.overwrite.folder)){
@@ -4975,20 +4996,20 @@ ddg.init <- function(r.script.path = NULL, ddgdir = NULL, overwrite = TRUE, enab
     }
     ddg.path <- paste(no.overwrite.folder, "/",  basename(tools::file_path_sans_ext(r.script.path)), "_ddg_", .ddg.timestamp(), sep = "")
   }
-
+  
   .ddg.set("ddg.path", ddg.path)
-
+  
   # Remove files from DDG directory
   ddg.flush.ddg()
-
+  
   # Create DDG directories
   .ddg.init.environ()
-
+  
   # Save copy of original script.
   file.copy(r.script.path, paste(.ddg.path.scripts(), "/", basename(r.script.path), sep = ""))
-
+  
   # Reset r.script.path if RMarkdown file
-
+  
   if (!is.null(r.script.path) && tools::file_ext(r.script.path) == "Rmd") {
     output.path <- paste(.ddg.path.scripts(), "/", basename(tools::file_path_sans_ext(r.script.path)), ".R", sep = "")
     .ddg.markdown(r.script.path, output.path)
@@ -4998,46 +5019,46 @@ ddg.init <- function(r.script.path = NULL, ddgdir = NULL, overwrite = TRUE, enab
              if (is.null(r.script.path)) NULL
              else normalizePath(r.script.path, winslash="/"))
   }
-
+  
   # Set environment constants.
   .ddg.set(".ddg.enable.console", enable.console)
   .ddg.set(".ddg.max.snapshot.size", max.snapshot.size)
   .ddg.set(".ddg.func.depth", 0)
   # .ddg.init.environ()
-
+  
   # Initialize the information about the open start-finish blocks
   .ddg.set (".ddg.starts.open", vector())
-
+  
   # Initialize the stack of commands and environments being executed in active functions
   .ddg.set(".ddg.cur.cmd.stack", vector())
   .ddg.set(".ddg.cur.expr.stack", vector())
-
+  
   # Mark graph as initilized.
   .ddg.set(".ddg.initialized", TRUE)
-
+  
   # Store the starting graphics device.
   .ddg.set("prev.device", dev.cur())
-
+  
   if (interactive() && .ddg.enable.console()) {
     ddg.history.file <- paste(.ddg.path.data(), "/.ddghistory", sep="")
     .ddg.set(".ddg.history.file", ddg.history.file)
-
+    
     # Empty file if it already exists, do the same with tmp file.
     file.create(ddg.history.file, showWarnings=FALSE)
-
+    
     # One timestamp keeps track of last ddg.save (the default).
     .ddg.write.timestamp.to.history()
-
+    
     # Save the history if the platform supports it.
     tryCatch (savehistory(ddg.history.file),
               error = function(e) {})
   }
-
+  
   .ddg.set(".ddg.proc.start.time", .ddg.elapsed.time())
-
+  
   # Store time when script begins execution.
   .ddg.set("ddg.start.time", .ddg.timestamp())
-
+  
   invisible()
 }
 
@@ -5085,7 +5106,7 @@ ddg.run <- function(r.script.path = NULL, ddgdir = NULL, overwrite = TRUE, f = N
 
   # Set .ddg.is.sourced to TRUE if script provided.
   if (!is.null(r.script.path)) .ddg.set(".ddg.is.sourced", TRUE)
-
+  
   # Set breakpoint if debug is TRUE.
   if (debug) ddg.breakpoint()
 
@@ -5112,14 +5133,11 @@ ddg.run <- function(r.script.path = NULL, ddgdir = NULL, overwrite = TRUE, f = N
       },
       finally={
         ddg.save(r.script.path)
-        if(display==TRUE){
-          disp <- ddg.display()
-          return(disp)
-        }else{
-          invisible()
-        }
+		    if(display == TRUE)
+			    .ddg.loadDDG(.ddg.path())
       }
   )
+  invisible()
 }
 
 # ddg.save inserts attribute information and the number of
@@ -5133,13 +5151,14 @@ ddg.run <- function(r.script.path = NULL, ddgdir = NULL, overwrite = TRUE, f = N
 # quit (optional) - If TRUE, remove all DDG files from memory.
 
 ddg.save <- function(r.script.path = NULL, save.debug = FALSE, quit = FALSE) {
+  
   if (!.ddg.is.init()) return(invisible())
-
+  
   if (interactive() && .ddg.enable.console()) {
     # Get the final commands
     .ddg.console.node()
   }
-
+  
    # If there is a display device open, grab what is on the display
    if (length(dev.list()) >= 1) {
      #print("ddg.save: Saving graphics open at end of script")
@@ -5147,18 +5166,18 @@ ddg.save <- function(r.script.path = NULL, save.debug = FALSE, quit = FALSE) {
      tryCatch (.ddg.capture.current.graphics(basename(.ddg.get("ddg.r.script.path"))),
          error = function (e) e)
    }
-
+  
   # Delete temporary files.
   # .ddg.delete.temp()
-
+  
   # Save ddg.txt to file.
   .ddg.txt.write()
   if (interactive()) print(paste("Saving ddg.txt in ", .ddg.path(), sep=""))
-
+  
   # Save ddg.json to file.
   .ddg.json.write()
   if (interactive()) print(paste("Saving ddg.json in ", .ddg.path(), sep=""))
-
+  
   # Save sourced scripts (if any). First row is main script.
   ddg.sourced.scripts <- .ddg.get(".ddg.sourced.scripts")
   if (!is.null(ddg.sourced.scripts)) {
@@ -5169,27 +5188,27 @@ ddg.save <- function(r.script.path = NULL, save.debug = FALSE, quit = FALSE) {
       }
     }
   }
-
+  
   # Save debug files to debug directory.
   if (save.debug | .ddg.save.debug()) {
     .ddg.save.debug.files()
   }
-
+  
   # By convention, this is the final call to ddg.save.
   if (quit) {
     # Restore history settings.
     if (.ddg.is.set('ddg.original.hist.size')) Sys.setenv("R_HISTSIZE"=.ddg.get('ddg.original.hist.size'))
-
+    
     # Delete temporary files.
     .ddg.delete.temp()
-
+    
     # Capture current graphics device.
     .ddg.auto.graphic.node(dev.to.capture=dev.cur)
-
+    
     # Shut down the DDG.
     .ddg.clear()
   }
-
+  
   invisible()
 }
 
@@ -5423,16 +5442,10 @@ ddg.source <- function (file,  ddgdir = NULL, local = FALSE, echo = verbose, pri
 # ddg.display loads & displays the current DDG.
 
 ddg.display <- function () {
-  jar.path<- "/RDataTracker/java/DDGExplorer.jar"
-  check.library.paths<- file.exists(paste(.libPaths(),jar.path,sep = ""))
-  index<- min(which(check.library.paths == TRUE))
-  ddgexplorer_path<- paste(.libPaths()[index],jar.path,sep = "")
-  ddgtxt.path<- paste(.ddg.path() ,"/ddg.txt",sep = "")
-  system(paste("java -jar ", ddgexplorer_path, ddgtxt.path, sep = " "), wait = FALSE)
-  
-  if(is.element('CamFlow', installed.packages()[,1])){ # did we install the CamFlow visualiser?
-    json <- .ddg.json.current()
-    CamFlowVisualiser(json)
+  if (.ddg.is.set("ddg.path") & file.exists(paste(.ddg.path(), "/ddg.txt", sep=""))) {
+    .ddg.loadDDG(.ddg.path())
+  } else {
+    print("DDG not available")
   }
 }
 
@@ -5545,7 +5558,7 @@ ddg.flush.ddg <- function(ddg.path=NULL) {
     ddg.path.debug <- .ddg.path.debug()
     ddg.path.scripts <- .ddg.path.scripts()
   }
-
+  
   # Remove files unless the DDG directory is the working directory.
   if (ddg.path != getwd()) {
     unlink(paste(ddg.path, "*.*", sep="/"))
@@ -5554,7 +5567,7 @@ ddg.flush.ddg <- function(ddg.path=NULL) {
     unlink(paste(ddg.path.debug, "*.*", sep="/"))
     unlink(paste(ddg.path.scripts, "*.*", sep="/"))
   }
-
+  
   invisible()
 }
 

--- a/R/RDataTracker.R
+++ b/R/RDataTracker.R
@@ -90,8 +90,12 @@ ddg.MAX_HIST_LINES <- 2^14
   return (.ddg.get("ddg.path"))
 }
 
+.ddg.data.dir <- function() {
+  return ("data")
+}
+
 .ddg.path.data <- function() {
-  return(paste(.ddg.path(), "/data", sep=""))
+  return(paste(.ddg.path(), .ddg.data.dir() , sep="/"))
 }
 
 .ddg.path.debug <- function() {
@@ -446,13 +450,13 @@ ddg.MAX_HIST_LINES <- 2^14
 
   # Table of sourced scripts
   .ddg.set(".ddg.sourced.scripts", NULL)
-  
+
   # Table of script, line & parsed command numbers
   .ddg.set(".ddg.source.parsed", NULL)
 
   # Save debug files on debug directory
   .ddg.set("ddg.save.debug", FALSE)
-  
+
 }
 
 # .ddg.set.history provides a wrapper to change the number of
@@ -472,7 +476,7 @@ ddg.MAX_HIST_LINES <- 2^14
   dir.create(.ddg.path.data(), showWarnings=FALSE)
   dir.create(.ddg.path.debug(), showWarnings=FALSE)
   dir.create(.ddg.path.scripts(), showWarnings=FALSE)
-  
+
   if (interactive() && .ddg.enable.console()) {
     .ddg.set('ddg.original.hist.size', Sys.getenv('R_HISTSIZE'))
     .ddg.set.history()
@@ -529,14 +533,14 @@ ddg.MAX_HIST_LINES <- 2^14
     ss <- ss[ss$snum > 0, ]
     stimes <- file.info(ss$sname)$mtime
     stimes <- .ddg.format.time(stimes)
-    
-    scriptarray <- paste("\t{\"number\" : \"", ss[ , 1], "\", 
+
+    scriptarray <- paste("\t{\"number\" : \"", ss[ , 1], "\",
                              \"name\" : \"",ss[ , 2], "\",
                              \"timestamp\" : \"",stimes, "\"}",
                          sep = "", collapse =",\n")
     output <- paste("[\n", scriptarray, " ],\n", sep = "")
   }
-  return(output)  
+  return(output)
 }
 
 # ddg.installedpackages() returns information on packages installed at the time of execution
@@ -674,7 +678,11 @@ ddg.MAX_HIST_LINES <- 2^14
 
   environ <- paste(environ, .ddg.json.nv("rdt:script", ddg.r.script.path), sep="")
 
-  environ <- paste(environ, "\"rdt:sourcedScripts\" : ", sourced.scripts, sep="")
+  if(sourced.scripts==""){
+    environ <- paste(environ, .ddg.json.nv("rdt:sourcedScripts", sourced.scripts), sep="")
+  }else{
+    environ <- paste(environ, "\"rdt:sourcedScripts\" : ", sourced.scripts, ",\n", sep="")
+  }
 
   environ <- paste(environ, .ddg.json.nv("rdt:scriptTimeStamp", script.timestamp), sep="")
 
@@ -702,21 +710,21 @@ ddg.MAX_HIST_LINES <- 2^14
 .ddg.json.procedure.node <- function(id, pname, ptype, ptime, snum, pos) {
 
   if (is.object(pos)) {
-    jstr <- paste("\n\"p", id, "\" : {\n\"rdt:name\" : \"", pname, "\",\n\"rdt:type\" : \"", ptype, 
-        "\",\n\"rdt:elapsedTime\" : \"", ptime, "\",\n\"rdt:scriptNum\" : \"", snum, 
-        "\",\n\"rdt:startLine\" : \"", pos@startLine, "\"", 
-        ",\n\"rdt:startCol\" : \"", pos@startCol, "\"", 
-        ",\n\"rdt:endLine\" : \"", pos@endLine, "\"", 
-        ",\n\"rdt:endCol\" : \"", pos@endCol, "\"", 
+    jstr <- paste("\n\"p", id, "\" : {\n\"rdt:name\" : \"", pname, "\",\n\"rdt:type\" : \"", ptype,
+        "\",\n\"rdt:elapsedTime\" : \"", ptime, "\",\n\"rdt:scriptNum\" : \"", snum,
+        "\",\n\"rdt:startLine\" : \"", pos@startLine, "\"",
+        ",\n\"rdt:startCol\" : \"", pos@startCol, "\"",
+        ",\n\"rdt:endLine\" : \"", pos@endLine, "\"",
+        ",\n\"rdt:endCol\" : \"", pos@endCol, "\"",
         "\n}", sep="")
   }
   else {
-    jstr <- paste("\n\"p", id, "\" : {\n\"rdt:name\" : \"", pname, "\",\n\"rdt:type\" : \"", ptype, 
-        "\",\n\"rdt:elapsedTime\" : \"", ptime, "\",\n\"rdt:scriptNum\" : \"", snum, 
-        "\",\n\"rdt:startLine\" : \"NA\"", 
-        ",\n\"rdt:startCol\" : \"NA\"", 
-        ",\n\"rdt:endLine\" : \"NA\"", 
-        ",\n\"rdt:endCol\" : \"NA\"", 
+    jstr <- paste("\n\"p", id, "\" : {\n\"rdt:name\" : \"", pname, "\",\n\"rdt:type\" : \"", ptype,
+        "\",\n\"rdt:elapsedTime\" : \"", ptime, "\",\n\"rdt:scriptNum\" : \"", snum,
+        "\",\n\"rdt:startLine\" : \"NA\"",
+        ",\n\"rdt:startCol\" : \"NA\"",
+        ",\n\"rdt:endLine\" : \"NA\"",
+        ",\n\"rdt:endCol\" : \"NA\"",
         "\n}", sep="")
   }
 
@@ -802,16 +810,16 @@ ddg.MAX_HIST_LINES <- 2^14
   } else value.str <- ""
 
   if (is.object(pos)) {
-    dtxt <- paste(ptype, " p", ddg.pnum, " \"", ddg.pnum, "-", pname, "\"", value.str, " Time=\"", ptime , 
+    dtxt <- paste(ptype, " p", ddg.pnum, " \"", ddg.pnum, "-", pname, "\"", value.str, " Time=\"", ptime ,
         "\" Script=\"", snum, "\"", " Pos=\"", pos@startLine, ",", pos@startCol, ",", pos@endLine, ",", pos@endCol, "\";\n", sep="")
     #print(".ddg.output.procedure.node: dtxt =")
     #print(dtxt)
   }
   else {
-    dtxt <- paste(ptype, " p", ddg.pnum, " \"", ddg.pnum, "-", pname, "\"", value.str, " Time=\"", ptime , 
+    dtxt <- paste(ptype, " p", ddg.pnum, " \"", ddg.pnum, "-", pname, "\"", value.str, " Time=\"", ptime ,
         "\" Script=\"", snum, "\"", " Pos=\"NA\";\n", sep="")
   }
-  
+
   # Record in ddg.txt
   .ddg.append(dtxt)
 
@@ -1195,7 +1203,7 @@ ddg.MAX_HIST_LINES <- 2^14
   ddg.proc.nodes$ddg.value[ddg.pnum] <- pvalue
   ddg.proc.nodes$ddg.auto.created[ddg.pnum] <- auto.created
   ddg.proc.nodes$ddg.time[ddg.pnum] <- ptime
-  
+
   ddg.proc.nodes$ddg.snum[ddg.pnum] <- snum
   if (is.object(pos) && length(pos@startLine == 1)) {
     ddg.proc.nodes$ddg.startLine[ddg.pnum] <- pos@startLine
@@ -1209,7 +1217,7 @@ ddg.MAX_HIST_LINES <- 2^14
     ddg.proc.nodes$ddg.endLine[ddg.pnum] <- NA
     ddg.proc.nodes$ddg.endCol[ddg.pnum] <- NA
   }
-  
+
   .ddg.set("ddg.proc.nodes", ddg.proc.nodes)
 
   # Output procedure node.
@@ -1256,7 +1264,7 @@ ddg.MAX_HIST_LINES <- 2^14
   if (length(dvalue) > 1 || !is.atomic(dvalue)) dvalue2 <- "complex"
   else if (!is.null(dvalue)) dvalue2 <- dvalue
   else dvalue2 <- ""
-  
+
   #print(".ddg.record.data: adding info")
   ddg.data.nodes$ddg.type[ddg.dnum] <- dtype
   ddg.data.nodes$ddg.num[ddg.dnum] <- ddg.dnum
@@ -1690,7 +1698,7 @@ ddg.MAX_HIST_LINES <- 2^14
 
 .ddg.add.to.vars.set <- function(vars.set, cmd, i) {
   #print("In .ddg.add.to.vars.set")
-  
+
   # Find out the variable being assigned to by a simple assignment
   # statement.
   main.var.assigned <- cmd@vars.set
@@ -1814,7 +1822,7 @@ ddg.MAX_HIST_LINES <- 2^14
   # Find all the variables used in this command.
   #print (paste(".ddg.create.data.use.edges.for.console.cmd: cmd = ", cmd@text))
   vars.used <- cmd@vars.used
-  
+
   for (var in vars.used) {
     #print(paste(".ddg.create.data.use.edges.for.console.cmd: var =", var))
     # Make sure there is a node we could connect to.
@@ -1892,14 +1900,14 @@ ddg.MAX_HIST_LINES <- 2^14
             eval (parse(text=var), parent.env(env))
           }
         )
-      
+
 			  tryCatch(.ddg.save.data(var, val, fname=".ddg.create.data.set.edges.for.cmd", error=TRUE, scope=scope, stack=stack, env=env),
 			         error = function(e){.ddg.data.node("Data", var, "complex", scope)})
 
         .ddg.proc2data(cmd@abbrev, var, scope)
     }
   }
-  
+
 }
 
 # .ddg.create.data.node.for.possible.writes creates a data node for
@@ -1932,7 +1940,7 @@ ddg.MAX_HIST_LINES <- 2^14
     }
   }
   #print("Done with .ddg.create.data.node.for.possible.writes")
-  
+
 }
 
 # Given a parse tree, this function returns a list containing
@@ -2214,14 +2222,14 @@ ddg.MAX_HIST_LINES <- 2^14
     file <- paste0("dev.off.", .ddg.dnum()+1, ".pdf")
   }
   #print(paste(".ddg.capture.graphics: writing to ", file))
-  
+
   # Save the graphic to a file temporarily
   #print(sys.calls())
   dev.print(device=pdf, file=file)
-  
+
   # Add it to the ddg.  This will copy the file to the right directory
   ddg.file.out (file, pname=cmd@abbrev)
-  
+
   # Remove the temporary file
   file.remove(file)
 }
@@ -2376,7 +2384,7 @@ ddg.MAX_HIST_LINES <- 2^14
   if (.ddg.debug.lib()) print(paste(called, ":  Adding", node.name,  type, "node"))
   .ddg.proc.node(type, node.name, node.name, TRUE, env=env, cmd = cmd)
   .ddg.proc2proc()
-  
+
   return(node.name)
 }
 
@@ -2520,7 +2528,7 @@ ddg.MAX_HIST_LINES <- 2^14
   if (!.ddg.get("ddg.break")) {
     writeLines("\nEnter = next command, C = next breakpoint, D = display DDG, Q = quit debugging\n")
   }
-  
+
   # Abbreviate command.
   abbrev <- command@abbrev
 
@@ -2547,7 +2555,7 @@ ddg.MAX_HIST_LINES <- 2^14
 
     print(paste("[", func.name, "]  |  ", abbrev, sep=""))
   }
-  
+
   # Save ddg.
   .ddg.txt.write()
   .ddg.json.write()
@@ -2556,19 +2564,19 @@ ddg.MAX_HIST_LINES <- 2^14
   line <- "D"
   while (line == "D") {
     line <- toupper(readline())
-    if (line == "D") .ddg.loadDDG(.ddg.path())
+    if (line == "D") ddg.display()
     else if (line == "") .ddg.set("ddg.break", TRUE)
     else if (line == "C") .ddg.set("ddg.break", FALSE)
     else if (line == "Q") .ddg.set("ddg.break.ignore", TRUE)
   }
-  
+
 }
 
 # Create the DDGStatement list for a list of parsed expressions.
 
 # exprs - a list of parsed expressions
 # script.name - the name of the script the expressions come from
-# annotate.functions - if true, we will place annotations inside function defintions so we can record 
+# annotate.functions - if true, we will place annotations inside function defintions so we can record
 #      provenance internal to them
 # parseData - information provided by the parser that we use to find line numbers
 # enclosing.pos - if exprs are statements within a function definition, enclosing.pos is the source position
@@ -2577,11 +2585,11 @@ ddg.MAX_HIST_LINES <- 2^14
 # Returns a list of DDGStatement objects
 
 .ddg.create.DDGStatements <- function (exprs, script.name, script.num, annotate.functions, parseData = NULL, enclosing.pos = NULL) {
-  
+
   # The parse data gives us line number information
   if (is.null(parseData)) {
     parseData <- getParseData(exprs, includeText=TRUE)
-    
+
     if (is.null(parseData)) {
       # In this case there is no line number information available
       cmds <- vector("list", (length(exprs)))
@@ -2597,50 +2605,50 @@ ddg.MAX_HIST_LINES <- 2^14
     if (nrow(non.comment.parse.data) == 0) {
       return(list())
     }
-    
+
     # Start at the first non-comment expression in parseData
     next.parseData <- 1
   }
-  
+
   else {
     non.comment.parse.data <- parseData[parseData$token != "COMMENT", ]
-    
+
     # Start at the first entry in parse data that begins after the enclosing function begins,
     # ends before the enclosing function ends, and matches the text of the first expression.
     next.parseData <- which(non.comment.parse.data$line1 >= enclosing.pos@startLine &
-            non.comment.parse.data$line2 <= enclosing.pos@endLine & 
+            non.comment.parse.data$line2 <= enclosing.pos@endLine &
             non.comment.parse.data$text == paste(deparse(exprs[[1]]), collapse="\n") )[1]
   }
-  
+
   # Get the breakpoint information
   breakpoints <- ddg.list.breakpoints()
   breakpoints <- breakpoints[breakpoints$sname == script.name, ]
-  
+
   # Create the DDGStatements
   cmds <- vector("list", (length(exprs)))
   next.cmd <- 1
   for (i in 1:length(exprs)) {
     expr <- as.expression(exprs[i])
-    next.expr.pos <- new (Class = "DDGStatementPos", 
+    next.expr.pos <- new (Class = "DDGStatementPos",
         non.comment.parse.data[next.parseData, ])
     cmds[[next.cmd]] <- .ddg.construct.DDGStatement(expr, next.expr.pos, script.name, script.num, breakpoints,
         annotate.functions, parseData)
     next.cmd <- next.cmd + 1
-    
+
     # If there are more expressions, determine where to look next in the parseData
     if (i < length(exprs)) {
        last.ending.line <- non.comment.parse.data[next.parseData,]$line2
        last.parent <- non.comment.parse.data[next.parseData,"parent"]
        last.id <- non.comment.parse.data[next.parseData,"id"]
-       
-       # Find the first entry in parseData that has the same parent as the 
+
+       # Find the first entry in parseData that has the same parent as the
        # previous expression and starts after the previous expression.
-       next.parseData <- which(non.comment.parse.data$parent == last.parent & 
+       next.parseData <- which(non.comment.parse.data$parent == last.parent &
                non.comment.parse.data$line1 >= last.ending.line &
                non.comment.parse.data$id > last.id) [1]
     }
   }
-  
+
   return (cmds)
 }
 
@@ -2672,7 +2680,7 @@ ddg.MAX_HIST_LINES <- 2^14
 # ddg.annotate.on and ddg.annotate.off may be used to limit the
 # functions that are annotated or not annotated, respectively.
 #
-# If run.commands is false, the commands are not executed.  This allows 
+# If run.commands is false, the commands are not executed.  This allows
 # us to build ddgs for commands run from the console as those commands
 # have already been executed.
 
@@ -2694,14 +2702,14 @@ ddg.MAX_HIST_LINES <- 2^14
 #   output for deparse of a single expression.
 # annotate.functions (optional) - if TRUE, functions are annotated
 # called.from.ddg.eval(optional) - whether called from ddg.eval
-# cmds - list of DDG Statements that correspond to the exprs passed in.  This is 
+# cmds - list of DDG Statements that correspond to the exprs passed in.  This is
 #   currently only used when called from ddg.eval.  Normally, ddg.parse.commands
 #   creates the DDG Statement objects.
 
-.ddg.parse.commands <- function (exprs, script.name="", script.num=NA, environ, ignore.patterns=c('^ddg.'), 
-    node.name="Console", run.commands = FALSE, echo=FALSE, print.eval=echo, max.deparse.length=150, 
+.ddg.parse.commands <- function (exprs, script.name="", script.num=NA, environ, ignore.patterns=c('^ddg.'),
+    node.name="Console", run.commands = FALSE, echo=FALSE, print.eval=echo, max.deparse.length=150,
     annotate.functions = FALSE, called.from.ddg.eval=FALSE, cmds=NULL) {
-  
+
   # Gather all the information that we need about the statements
   if (is.null(cmds)) {
     cmds <- .ddg.create.DDGStatements (exprs, script.name, script.num, annotate.functions)
@@ -2711,17 +2719,17 @@ ddg.MAX_HIST_LINES <- 2^14
     }
   }
   num.cmds <- length(cmds)
-  
+
   # Figure out if we will execute commands or not.
   execute <- run.commands & !is.null(environ) & is.environment(environ)
-  
+
   #print (paste("ddg.parse.commands: .ddg.func.depth =", .ddg.get(".ddg.func.depth")))
   inside.func <- (.ddg.get(".ddg.func.depth") > 0)
-  
+
   # Attempt to close the previous collapsible command node if a ddg
   # exists
   if (.ddg.is.init() && !inside.func) .ddg.close.last.command.node(environ, initial=TRUE)
-  
+
   # Get the last command in the new commands and check to see if
   # we need to create a new .ddg.last.cmd node for future reference.
   if (!inside.func) {
@@ -2731,12 +2739,12 @@ ddg.MAX_HIST_LINES <- 2^14
       .ddg.last.cmd <- NULL
       #print(".ddg.parse.commands: setting .ddg.last.cmd to null")
     }
-    
+
     else if (!execute) {
       cmds <- cmds[1:num.cmds-1]
     }
   }
-  
+
   # Create start and end nodes to allow collapsing of consecutive
   # console nodes. Don't bother doing this if there is only 1 new
   # command in the history or execution.
@@ -2749,11 +2757,11 @@ ddg.MAX_HIST_LINES <- 2^14
     named.node.set <- TRUE
     start.node.created <- node.name
   }
-  
+
   # Don't set .ddg.last.cmd.  We want it to have the value from
   # the last call. We set it at the end of this function:
   # .ddg.set(".ddg.last.cmd", .ddg.last.cmd)
-  
+
   # Create an operation node for each command.  We can't use lapply
   # here because we need to process the commands in order and
   # lapply does not guarantee an order. Also decide which data nodes
@@ -2764,10 +2772,10 @@ ddg.MAX_HIST_LINES <- 2^14
   # the last writer/possible writer. Lastly, if environ is set to
   # true, then execute each command immediately before attempting
   # to create the DDG nodes.
-  
+
   # Only go through this if  we have at least one command to parse.
   if (num.cmds > 0) {
-    
+
     # Find where all the variables are assigned for non-environ
     # files.
     if (!execute) {
@@ -2781,20 +2789,20 @@ ddg.MAX_HIST_LINES <- 2^14
     for (i in 1:length(cmds)) {
       cmd <- cmds[[i]]
       if (.ddg.debug.lib()) print(paste(".ddg.parse.commands: Processing", cmd@abbrev))
-      
+
       # Process breakpoint. We stop if there is a breakpoint set on this line or we are single-stepping.
       #print("Checking for breakpoints")
       if (.ddg.is.sourced() & (cmd@is.breakpoint | .ddg.get("ddg.break")) & !.ddg.break.ignore()) {
         .ddg.process.breakpoint(cmd, inside.function=called.from.ddg.eval)
       }
-      
+
       #print("Checking whether to set last.cmd")
       if (.ddg.enable.source() && grepl("^ddg.eval", cmd@text) && .ddg.enable.console()) {
         if (is.null(.ddg.last.cmd)) {
           .ddg.last.cmd <- cmd
         }
       }
-      
+
       # Get environment for output data node.
       d.environ <- environ
       if ( .ddg.is.nonlocal.assign(cmd@parsed[[1]]) ) 
@@ -2812,13 +2820,13 @@ ddg.MAX_HIST_LINES <- 2^14
       # Specifies whether or not a procedure node should be created
       # for this command. Basically, if a ddg exists and the
       # command is not a DDG command, it should be created.
-      
+
       create <- !cmd@isDdgFunc && .ddg.is.init() && .ddg.enable.console()
       start.finish.created <- FALSE
-      
+
       # If the command does not match one of the ignored patterns.
       if (!any(sapply(ignore.patterns, function(pattern){grepl(pattern, cmd@text)}))) {
-        
+
         # If sourcing, we want to execute the command.
         if (execute) {
           # Print command.
@@ -2830,19 +2838,19 @@ ddg.MAX_HIST_LINES <- 2^14
                         else nd), "\n")
             cat(cmd.show)
           }
-          
+
           # If we will create a node, then before execution, set
           # this command as a possible abstraction node but only
           # if it's not a call that itself creates abstract nodes.
           if (!cmd@isDdgFunc) {
             .ddg.set(".ddg.possible.last.cmd", cmd)
             .ddg.set (".ddg.cur.cmd", cmd)
-            
+
             # Remember the current statement on the stack so that we
             # will be able to create a corresponding Finish node later
             # if needed.
             .ddg.cur.cmd.stack <- .ddg.get(".ddg.cur.cmd.stack")
-            
+
             if (length(.ddg.cur.cmd.stack) == 0) {
               .ddg.cur.cmd.stack <- c(cmd, FALSE)
             }
@@ -2851,11 +2859,11 @@ ddg.MAX_HIST_LINES <- 2^14
             }
             .ddg.set(".ddg.cur.cmd.stack", .ddg.cur.cmd.stack)
           }
-          
+
           else if (.ddg.is.procedure.cmd(cmd)) {
             .ddg.set(".ddg.possible.last.cmd", NULL)
           }
-          
+
           # Capture any warnings that occur when an expression is evaluated.
           # Note that we cannot just use a tryCatch here because it behaves slightly differently
           # and we would lose the value that eval returns.  withCallingHandlers returns the value.
@@ -2864,14 +2872,14 @@ ddg.MAX_HIST_LINES <- 2^14
           if (.ddg.debug.lib()) print (paste (".ddg.parse.commands evaluating ", cmd@annotated))
           result <- withCallingHandlers (eval(cmd@annotated, environ, NULL), warning = .ddg.set.warning)
           if (.ddg.debug.lib()) print (paste (".ddg.parse.commands done evaluating ", cmd@annotated))
-          
+
           if (!cmd@isDdgFunc) {
             # Need to get the stack again because it could have been
             # modified during the eval call.
             .ddg.cur.cmd.stack <- .ddg.get(".ddg.cur.cmd.stack")
             stack.length <- length(.ddg.cur.cmd.stack)
             start.created <- .ddg.cur.cmd.stack[stack.length][[1]]
-            
+
             # Create a finish node if a start node was created
             # start.created can have one of 3 values: "TRUE", "FALSE",
             # "MATCHES_CALL". Only create the finish node if TRUE.
@@ -2880,7 +2888,7 @@ ddg.MAX_HIST_LINES <- 2^14
               start.finish.created <- TRUE
               .ddg.link.function.returns(cmd)
             }
-            
+
             # Remove the last command & start.created values pushed
             # onto the stack
             if (stack.length == 2) {
@@ -2890,34 +2898,34 @@ ddg.MAX_HIST_LINES <- 2^14
               .ddg.set(".ddg.cur.cmd.stack", .ddg.cur.cmd.stack[1:(stack.length-2)])
             }
           }
-          
+
           # Print evaluation.
           if (print.eval) print(result)
-          
+
         }
-        
+
         # Figure out if we should create a procedure node for this
         # command. We don't create it if it matches a last command
         # (because that last command has now become a collapsible
         # node). Matching a last command means that the last command
         # is set, is not NULL, and is equal to the current command.
-        
+
         last.proc.node.created <-
             if (.ddg.is.set (".ddg.last.proc.node.created")).ddg.get(".ddg.last.proc.node.created")
             else ""
         cur.cmd.closed <- (last.proc.node.created == paste ("Finish", cmd@abbrev))
         create.procedure <- create && (!cur.cmd.closed || !named.node.set) && !start.finish.created  && !grepl("^ddg.source", cmd@text)
-        
+
         # We want to create a procedure node for this command.
         if (create.procedure) {
-          
+
           # Create the procedure node.
-          
+
           if (.ddg.debug.lib()) print(paste(".ddg.parse.commands: Adding operation node for", cmd@abbrev))
-          
+
           .ddg.proc.node("Operation", cmd@abbrev, cmd@abbrev, env=environ, console=TRUE, cmd=cmd)
           .ddg.proc2proc()
-          
+
           # If a warning occurred when cmd was evaluated,
           # attach a warning node
           if (.ddg.warning.occurred()) {
@@ -2926,7 +2934,7 @@ ddg.MAX_HIST_LINES <- 2^14
           # Store information on the last procedure node in this
           # block.
           last.proc.node <- cmd
-          
+
           # We want to create the incoming data nodes (by updating
           # the vars.set).
           if (execute) {
@@ -2934,15 +2942,15 @@ ddg.MAX_HIST_LINES <- 2^14
             vars.set <- .ddg.add.to.vars.set(vars.set,cmd,i)
             if (.ddg.debug.lib()) print(paste(".ddg.parse.commands: Adding", cmd@abbrev, "information to vars.set"))
           }
-          
+
           .ddg.create.data.use.edges.for.console.cmd(vars.set, cmd, i, for.caller=FALSE)
           if (cmd@readsFile) .ddg.create.file.read.nodes.and.edges(cmd, environ)
           .ddg.link.function.returns(cmd)
-          
+
           if (.ddg.debug.lib()) print(paste(".ddg.parse.commands: Adding input data nodes for", cmd@abbrev))
           .ddg.create.data.set.edges.for.cmd(vars.set, cmd, i, d.environ)
           if (.ddg.debug.lib()) print(paste(".ddg.parse.commands: Adding output data nodes for", cmd@abbrev))
-          
+
           if (cmd@writesFile) .ddg.create.file.write.nodes.and.edges (cmd, environ)
           .ddg.set.graphics.files (cmd, environ)
           if (cmd@has.dev.off) {
@@ -2959,16 +2967,16 @@ ddg.MAX_HIST_LINES <- 2^14
             .ddg.create.data.set.edges.for.cmd(vars.set, cmd, i, environ)
           }
         }
-        
+
         if (create.procedure && execute) {
           .ddg.create.data.node.for.possible.writes(vars.set, last.proc.node, env=environ)
-          
+
           # Update so we don't set these again.
           vars.set$possible.last.writer <- vars.set$last.writer
         }
       }
      }
-     
+
      # Create a data node for each variable that might have been set in
      # something other than a simple assignment, with an edge from the
      # last node in the console block or source .
@@ -2976,31 +2984,31 @@ ddg.MAX_HIST_LINES <- 2^14
        .ddg.create.data.node.for.possible.writes(vars.set, last.proc.node, env=environ)
      }
   }
-  
+
   #print("Done with ddg.parse.commands loop")
-    
+
   # Close any node left open during execution.
   if (execute && !inside.func) .ddg.close.last.command.node(environ, initial=TRUE)
-  
+
   # Close the console block if we processed anything and the DDG
   # is initialized (also, save).
   #
   if (.ddg.is.init() && named.node.set && !inside.func) {
     .ddg.add.abstract.node("Finish", node.name = node.name, env=environ)
   }
-  
+
   # Open up a new collapsible node in case we need to parse
   # further later.
   if (!execute) {
-    
+
     .ddg.set(".ddg.possible.last.cmd", .ddg.last.cmd)
     .ddg.set(".ddg.last.cmd", .ddg.last.cmd)
     .ddg.open.new.command.node(environ)
   }
-  
+
   # Write time stamp to history.
   if (.ddg.is.init() && !.ddg.is.sourced()) .ddg.write.timestamp.to.history()
-  
+
 }
 
 
@@ -3055,12 +3063,12 @@ ddg.MAX_HIST_LINES <- 2^14
 # env - the environment in which the procedure occurs
 
 # CHECK!  Looks like env parameter is not needed!
-.ddg.proc.node <- function(ptype, pname, pvalue="", console=FALSE, 
-    auto.created=FALSE, env = sys.frame(.ddg.get.frame.number(sys.calls())), 
+.ddg.proc.node <- function(ptype, pname, pvalue="", console=FALSE,
+    auto.created=FALSE, env = sys.frame(.ddg.get.frame.number(sys.calls())),
     cmd = NULL) {
   if (.ddg.debug.lib()) {
-  	if (length(pname) > 1) {
-    	print(sys.calls())
+    if (length(pname) > 1) {
+      print(sys.calls())
     }
   }
 
@@ -3222,13 +3230,13 @@ ddg.MAX_HIST_LINES <- 2^14
         # Replace double quotes with single quotes.
         .ddg.replace.quotes(dvalue)
       }
-      
+
   #print(".ddg.data.node: converted value to string")
-      
+
 
   if (grepl("\n", val)) {
     #print(".ddg.data.node: saving as snapshot")
-    
+
     # Create snapshot node.
     .ddg.snapshot.node (dname, "txt", val, from.env=from.env)
     return
@@ -3236,7 +3244,7 @@ ddg.MAX_HIST_LINES <- 2^14
 
   else {
     #print(".ddg.data.node: recording data")
-    
+
     # Get scope if necessary.
     if (is.null(dscope)) dscope <- .ddg.get.scope(dname)
 
@@ -3434,9 +3442,10 @@ ddg.MAX_HIST_LINES <- 2^14
 	# Add number to file name.
 	dfile <- paste(.ddg.dnum()+1, "-", file.name, sep="")
 
-	# Get path plus file name.
-	dpfile <- paste(.ddg.path.data(), "/", dfile, sep="")
-
+  # Calculate the path to the file relative to the ddg directory.
+  # This is the value stored in the node.
+  dpfile <- paste(.ddg.data.dir(), dfile, sep="/")
+  
 	dtime <- .ddg.timestamp()
 
 	# Set the node label.
@@ -3451,7 +3460,9 @@ ddg.MAX_HIST_LINES <- 2^14
   # Record in data node table
   .ddg.record.data(dtype, dname, dpfile, dscope, from.env=from.env, dtime, file.loc)
 
-  return(dpfile)
+  # Get path plus file name to where the file will be copied
+  dpath <- paste(.ddg.path.data(), "/", dfile, sep="")
+  return(dpath)
 }
 
 # .ddg.file.copy creates a data node of type File. File nodes are
@@ -4049,41 +4060,41 @@ ddg.MAX_HIST_LINES <- 2^14
 # created. If eval = false, then the chunk will not be added to the DDG. If
 # the user has a name for the chunk, then that name will be used, else a chunk
 # name "ddg.chunk_1" and higher numbers will be generated.
-# 
+#
 # Important: If in a code chunk, there is an empty line followed by "# ----"
 # or "#'", then an extra finish node will be inserted, causing an error.
-# 
+#
 # r.script.path is the path of the original Rmd file
 # output.path is the path of the generated R script
 
 .ddg.markdown <- function(r.script.path = NULL, output.path = NULL){
-  
+
   #generates R script file from markdown file
   knitr::purl(r.script.path, documentation = 2L, quiet = TRUE)
-  
+
   #moves file to ddg directory
   file.rename(from = paste(getwd(), "/", basename(tools::file_path_sans_ext(r.script.path)), ".R", sep = ""), to = output.path)
   script <- readLines(output.path)
-  
+
   skip <- FALSE
   name <- "ddg.chunk"
   annotated <- character(0)
   index <- 1
-  
-  
+
+
   # This for loop goes through the script line by line and searches for patterns
   # to insert the start and finish nodes
   for(i in 1:length(script)){
-    
+
     #eval = false means we skip this code chunk, therefore skip = TRUE
     if(regexpr("eval+(\\s*)+=+(\\s*)+FALSE", script[i]) != -1){
       skip <- TRUE
       annotated <- append(annotated, script[i])
     }
-    
+
     else if(regexpr("## ----", script[i]) != -1){
-      
-      #if no options in the line, then generate default name.      
+
+      #if no options in the line, then generate default name.
       if(regexpr("## -----", script[i]) == -1){
         if(regexpr("=", script[i]) == -1){
           end <- regexpr("-----", script[i])
@@ -4105,7 +4116,7 @@ ddg.MAX_HIST_LINES <- 2^14
       name <- stringr::str_trim(name, side = "both")
       annotated <- append(annotated, paste("ddg.start(\"", name, "\")", sep = ""))
     }
-    else if(nchar(script[i]) == 0 && (regexpr("#'", script[i + 1]) != -1 || 
+    else if(nchar(script[i]) == 0 && (regexpr("#'", script[i + 1]) != -1 ||
                                       i == length(script) || regexpr("## ----", script[i + 1]) != -1 )){
       if(skip){
         annotated <- append(annotated, script[i])
@@ -4130,31 +4141,31 @@ ddg.MAX_HIST_LINES <- 2^14
   fileout <- paste(.ddg.path.debug(), "/initial-environment.csv", sep="")
   ddg.initial.env <- .ddg.initial.env()
   write.csv(ddg.initial.env, fileout, row.names=FALSE)
-  
+
   # Save procedure nodes table to file.
   fileout <- paste(.ddg.path.debug(), "/procedure-nodes.csv", sep="")
   ddg.proc.nodes <- .ddg.proc.nodes()
   ddg.proc.nodes <- ddg.proc.nodes[ddg.proc.nodes$ddg.num > 0, ]
   write.csv(ddg.proc.nodes, fileout, row.names=FALSE)
-  
+
   # Save data nodes table to file.
   fileout <- paste(.ddg.path.debug(), "/data-nodes.csv", sep="")
   ddg.data.nodes <- .ddg.data.nodes()
   ddg.data.nodes2 <- ddg.data.nodes[ddg.data.nodes$ddg.num > 0, ]
   write.csv(ddg.data.nodes2, fileout, row.names=FALSE)
-  
+
   # Save edges table to file.
   fileout <- paste(.ddg.path.debug(), "/edges.csv", sep="")
   ddg.edges <- .ddg.edges()
   ddg.edges2 <- ddg.edges[ddg.edges$ddg.num > 0, ]
   write.csv(ddg.edges2, fileout, row.names=FALSE)
-  
+
   # Save function return table to file.
   fileout <- paste(.ddg.path.debug(), "/function-returns.csv", sep="")
   ddg.returns <- .ddg.get(".ddg.return.values")
   ddg.returns2 <- ddg.returns[ddg.returns$return.node.id > 0, ]
   write.csv(ddg.returns2, fileout, row.names=FALSE)
-  
+
   # Save if script is sourced.
   if (.ddg.is.sourced()) {
     # Save sourced script table to file.
@@ -4162,7 +4173,7 @@ ddg.MAX_HIST_LINES <- 2^14
     ddg.sourced.scripts <- .ddg.get(".ddg.sourced.scripts")
     ddg.sourced.scripts2 <- ddg.sourced.scripts[ddg.sourced.scripts$snum >= 0, ]
     write.csv(ddg.sourced.scripts2, fileout, row.names=FALSE)
-    
+
     # Save data object table to file.
     fileout <- paste(.ddg.path.debug(), "/data-objects.csv", sep="")
     ddg.data.objects <- .ddg.data.objects()
@@ -4372,12 +4383,12 @@ ddg.return.value <- function (expr=NULL, cmd.func=NULL) {
 
   # If expr is an assignment, create nodes and edges for the assignment.
   orig.expr <- substitute(expr)
-  
+
   frame.num <- .ddg.get.frame.number(sys.calls())
   env <- sys.frame(frame.num)
 
   orig.return <- paste("return(", deparse(orig.expr), ")", sep="")
-  
+
   pname <- NULL
   .ddg.lookup.function.name(pname)
 
@@ -4443,7 +4454,7 @@ ddg.return.value <- function (expr=NULL, cmd.func=NULL) {
     return.stmt <- cmd.func()
     parsed.statement <- return.stmt@parsed
   }
-  
+
   # Process breakpoint. We stop if there is a breakpoint set on this line or we are single-stepping.
   if (.ddg.is.sourced() & (return.stmt@is.breakpoint | .ddg.get("ddg.break")) & !.ddg.break.ignore()) {
     .ddg.process.breakpoint(return.stmt, inside.function=TRUE)
@@ -4457,7 +4468,7 @@ ddg.return.value <- function (expr=NULL, cmd.func=NULL) {
 
   # Create an edge from the return statement to its return value.
   .ddg.proc2data(return.stmt@abbrev, return.node.name, return.node.scope, return.value=TRUE)
-  
+
   # Update the table.
   ddg.num.returns <- ddg.num.returns + 1
   ddg.return.values$ddg.call[ddg.num.returns] <- call.text
@@ -4465,7 +4476,7 @@ ddg.return.value <- function (expr=NULL, cmd.func=NULL) {
   ddg.return.values$return.node.id[ddg.num.returns] <- .ddg.dnum()
   .ddg.set(".ddg.return.values", ddg.return.values)
   .ddg.set(".ddg.num.returns", ddg.num.returns)
-  
+
   # Create edges from variables used in the return statement
   vars.used <- return.stmt@vars.used
   for (var in vars.used) {
@@ -4506,7 +4517,7 @@ ddg.return.value <- function (expr=NULL, cmd.func=NULL) {
   if (return.stmt@has.dev.off) {
     .ddg.capture.graphics(return.stmt)
   }
-  
+
   # Create the finish node for the function
   if (typeof(call[[1]]) == "closure") {
     .ddg.add.abstract.node ("Finish", node.name=pname, env=caller.env)
@@ -4540,7 +4551,7 @@ ddg.eval <- function(statement, cmd.func=NULL) {
     #print(cmd@pos)
   }
   if (.ddg.debug.lib()) print (paste("ddg.eval: statement =", statement))
-  
+
   frame.num <- .ddg.get.frame.number(sys.calls())
   env <- sys.frame(frame.num)
 
@@ -4975,10 +4986,10 @@ ddg.finish <- function(pname=NULL) {
 ddg.init <- function(r.script.path = NULL, ddgdir = NULL, overwrite = TRUE, enable.console = TRUE, max.snapshot.size = 100) {
   #.ddg.DDGStatement.init()
   .ddg.init.tables()
-  
-  # Setting the path for the ddg    
+
+  # Setting the path for the ddg
   if (is.null(ddgdir)) {
-    
+
     # Default is the file where the script is located
     if (!is.null(r.script.path)){
       ddg.path <- paste(dirname(r.script.path), "/", basename(tools::file_path_sans_ext(r.script.path)), "_ddg", sep="")
@@ -4987,8 +4998,8 @@ ddg.init <- function(r.script.path = NULL, ddgdir = NULL, overwrite = TRUE, enab
       ddg.path <- paste(getwd(), "/","ddg",sep = "")
     }
   } else ddg.path <- normalizePath(ddgdir, winslash="/", mustWork=FALSE)
-  
-  # Overwrite default is 
+
+  # Overwrite default is
   if(!overwrite){
     no.overwrite.folder <- paste(ddg.path, "_timestamps", sep = "")
     if(!dir.exists(no.overwrite.folder)){
@@ -4996,20 +5007,20 @@ ddg.init <- function(r.script.path = NULL, ddgdir = NULL, overwrite = TRUE, enab
     }
     ddg.path <- paste(no.overwrite.folder, "/",  basename(tools::file_path_sans_ext(r.script.path)), "_ddg_", .ddg.timestamp(), sep = "")
   }
-  
+
   .ddg.set("ddg.path", ddg.path)
-  
+
   # Remove files from DDG directory
   ddg.flush.ddg()
-  
+
   # Create DDG directories
   .ddg.init.environ()
-  
+
   # Save copy of original script.
   file.copy(r.script.path, paste(.ddg.path.scripts(), "/", basename(r.script.path), sep = ""))
-  
+
   # Reset r.script.path if RMarkdown file
-  
+
   if (!is.null(r.script.path) && tools::file_ext(r.script.path) == "Rmd") {
     output.path <- paste(.ddg.path.scripts(), "/", basename(tools::file_path_sans_ext(r.script.path)), ".R", sep = "")
     .ddg.markdown(r.script.path, output.path)
@@ -5019,46 +5030,46 @@ ddg.init <- function(r.script.path = NULL, ddgdir = NULL, overwrite = TRUE, enab
              if (is.null(r.script.path)) NULL
              else normalizePath(r.script.path, winslash="/"))
   }
-  
+
   # Set environment constants.
   .ddg.set(".ddg.enable.console", enable.console)
   .ddg.set(".ddg.max.snapshot.size", max.snapshot.size)
   .ddg.set(".ddg.func.depth", 0)
   # .ddg.init.environ()
-  
+
   # Initialize the information about the open start-finish blocks
   .ddg.set (".ddg.starts.open", vector())
-  
+
   # Initialize the stack of commands and environments being executed in active functions
   .ddg.set(".ddg.cur.cmd.stack", vector())
   .ddg.set(".ddg.cur.expr.stack", vector())
-  
+
   # Mark graph as initilized.
   .ddg.set(".ddg.initialized", TRUE)
-  
+
   # Store the starting graphics device.
   .ddg.set("prev.device", dev.cur())
-  
+
   if (interactive() && .ddg.enable.console()) {
     ddg.history.file <- paste(.ddg.path.data(), "/.ddghistory", sep="")
     .ddg.set(".ddg.history.file", ddg.history.file)
-    
+
     # Empty file if it already exists, do the same with tmp file.
     file.create(ddg.history.file, showWarnings=FALSE)
-    
+
     # One timestamp keeps track of last ddg.save (the default).
     .ddg.write.timestamp.to.history()
-    
+
     # Save the history if the platform supports it.
     tryCatch (savehistory(ddg.history.file),
               error = function(e) {})
   }
-  
+
   .ddg.set(".ddg.proc.start.time", .ddg.elapsed.time())
-  
+
   # Store time when script begins execution.
   .ddg.set("ddg.start.time", .ddg.timestamp())
-  
+
   invisible()
 }
 
@@ -5106,7 +5117,7 @@ ddg.run <- function(r.script.path = NULL, ddgdir = NULL, overwrite = TRUE, f = N
 
   # Set .ddg.is.sourced to TRUE if script provided.
   if (!is.null(r.script.path)) .ddg.set(".ddg.is.sourced", TRUE)
-  
+
   # Set breakpoint if debug is TRUE.
   if (debug) ddg.breakpoint()
 
@@ -5133,11 +5144,14 @@ ddg.run <- function(r.script.path = NULL, ddgdir = NULL, overwrite = TRUE, f = N
       },
       finally={
         ddg.save(r.script.path)
-		    if(display == TRUE)
-			    .ddg.loadDDG(.ddg.path())
+        if(display==TRUE){
+          disp <- ddg.display()
+          return(disp)
+        }else{
+          invisible()
+        }
       }
   )
-  invisible()
 }
 
 # ddg.save inserts attribute information and the number of
@@ -5151,14 +5165,13 @@ ddg.run <- function(r.script.path = NULL, ddgdir = NULL, overwrite = TRUE, f = N
 # quit (optional) - If TRUE, remove all DDG files from memory.
 
 ddg.save <- function(r.script.path = NULL, save.debug = FALSE, quit = FALSE) {
-  
   if (!.ddg.is.init()) return(invisible())
-  
+
   if (interactive() && .ddg.enable.console()) {
     # Get the final commands
     .ddg.console.node()
   }
-  
+
    # If there is a display device open, grab what is on the display
    if (length(dev.list()) >= 1) {
      #print("ddg.save: Saving graphics open at end of script")
@@ -5166,18 +5179,18 @@ ddg.save <- function(r.script.path = NULL, save.debug = FALSE, quit = FALSE) {
      tryCatch (.ddg.capture.current.graphics(basename(.ddg.get("ddg.r.script.path"))),
          error = function (e) e)
    }
-  
+
   # Delete temporary files.
   # .ddg.delete.temp()
-  
+
   # Save ddg.txt to file.
   .ddg.txt.write()
   if (interactive()) print(paste("Saving ddg.txt in ", .ddg.path(), sep=""))
-  
+
   # Save ddg.json to file.
   .ddg.json.write()
   if (interactive()) print(paste("Saving ddg.json in ", .ddg.path(), sep=""))
-  
+
   # Save sourced scripts (if any). First row is main script.
   ddg.sourced.scripts <- .ddg.get(".ddg.sourced.scripts")
   if (!is.null(ddg.sourced.scripts)) {
@@ -5188,27 +5201,27 @@ ddg.save <- function(r.script.path = NULL, save.debug = FALSE, quit = FALSE) {
       }
     }
   }
-  
+
   # Save debug files to debug directory.
   if (save.debug | .ddg.save.debug()) {
     .ddg.save.debug.files()
   }
-  
+
   # By convention, this is the final call to ddg.save.
   if (quit) {
     # Restore history settings.
     if (.ddg.is.set('ddg.original.hist.size')) Sys.setenv("R_HISTSIZE"=.ddg.get('ddg.original.hist.size'))
-    
+
     # Delete temporary files.
     .ddg.delete.temp()
-    
+
     # Capture current graphics device.
     .ddg.auto.graphic.node(dev.to.capture=dev.cur)
-    
+
     # Shut down the DDG.
     .ddg.clear()
   }
-  
+
   invisible()
 }
 
@@ -5442,10 +5455,16 @@ ddg.source <- function (file,  ddgdir = NULL, local = FALSE, echo = verbose, pri
 # ddg.display loads & displays the current DDG.
 
 ddg.display <- function () {
-  if (.ddg.is.set("ddg.path") & file.exists(paste(.ddg.path(), "/ddg.txt", sep=""))) {
-    .ddg.loadDDG(.ddg.path())
-  } else {
-    print("DDG not available")
+  jar.path<- "/RDataTracker/java/DDGExplorer.jar"
+  check.library.paths<- file.exists(paste(.libPaths(),jar.path,sep = ""))
+  index<- min(which(check.library.paths == TRUE))
+  ddgexplorer_path<- paste(.libPaths()[index],jar.path,sep = "")
+  ddgtxt.path<- paste(.ddg.path() ,"/ddg.txt",sep = "")
+  system(paste("java -jar ", ddgexplorer_path, ddgtxt.path, sep = " "), wait = FALSE)
+  
+  if(is.element('CamFlow', installed.packages()[,1])){ # did we install the CamFlow visualiser?
+    json <- .ddg.json.current()
+    CamFlowVisualiser(json)
   }
 }
 
@@ -5558,7 +5577,7 @@ ddg.flush.ddg <- function(ddg.path=NULL) {
     ddg.path.debug <- .ddg.path.debug()
     ddg.path.scripts <- .ddg.path.scripts()
   }
-  
+
   # Remove files unless the DDG directory is the working directory.
   if (ddg.path != getwd()) {
     unlink(paste(ddg.path, "*.*", sep="/"))
@@ -5567,7 +5586,7 @@ ddg.flush.ddg <- function(ddg.path=NULL) {
     unlink(paste(ddg.path.debug, "*.*", sep="/"))
     unlink(paste(ddg.path.scripts, "*.*", sep="/"))
   }
-  
+
   invisible()
 }
 

--- a/R/RDataTracker.R
+++ b/R/RDataTracker.R
@@ -2807,15 +2807,7 @@ ddg.MAX_HIST_LINES <- 2^14
       d.environ <- environ
       if ( .ddg.is.nonlocal.assign(cmd@parsed[[1]]) ) 
       {
-      	#for( var in cmd@vars.set)
-      	#{
       		d.environ <- .ddg.where( cmd@vars.set , parent.env(parent.frame()) )
-
-      		#if( d.environ == "undefined" )
-      		#{
-      		#	d.environ <- globalenv()
-      		#}
-      	#}
       }
 
       # Specifies whether or not a procedure node should be created
@@ -4489,7 +4481,8 @@ ddg.return.value <- function (expr=NULL, cmd.func=NULL) {
   }
 
   for (var in return.stmt@vars.set) {
-    if (var != "") {
+    if (var != "") 
+    {
       # Create output data node.
       dvalue <- eval(as.symbol(var), envir=env)
 
@@ -4497,14 +4490,11 @@ ddg.return.value <- function (expr=NULL, cmd.func=NULL) {
       if ( .ddg.is.nonlocal.assign(return.stmt@parsed[[1]]) )
       {
       	env <- .ddg.where( var, parent.env(parent.frame()) )
-
-      	#if( env == "undefined" )
-      	#{
-      	#	env <- globalenv()
-      	#}
       }
+
       dscope <- .ddg.get.scope(var, env=env)
       .ddg.save.data(var, dvalue, scope=dscope)
+      
       # Create an edge from procedure node to data node.
       .ddg.proc2data(return.stmt@abbrev, var, dscope=dscope, return.value=FALSE)
     }

--- a/R/RDataTracker.R
+++ b/R/RDataTracker.R
@@ -48,7 +48,10 @@ ddg.MAX_HIST_LINES <- 2^14
 .ddg.set <- function(var, value) {
   .ddg.env[[var]] <- value
   #return(invisible(.ddg.env[[var]]))
-  print(paste("variable:",var,", value:",value))
+  if( var == "ddg.data.nodes" )
+  {
+    print(paste("variable:",var,", value:",value))
+  }
   return(.ddg.env[[var]])
 }
 

--- a/R/RDataTracker.R
+++ b/R/RDataTracker.R
@@ -2789,7 +2789,7 @@ ddg.MAX_HIST_LINES <- 2^14
     else {
       vars.set <- .ddg.create.empty.vars.set()
     }
-
+    
     # Loop over the commands as well as their string representations.
     for (i in 1:length(cmds)) {
       cmd <- cmds[[i]]
@@ -2812,16 +2812,17 @@ ddg.MAX_HIST_LINES <- 2^14
       d.environ <- environ
       if ( .ddg.is.nonlocal.assign(cmd@parsed[[1]]) ) 
       {
-      	for( var in cmd@vars.set)
-      	{
-      		d.environ <- .ddg.where( var , parent.env(parent.frame()) )
+      	#for( var in cmd@vars.set)
+      	#{
+      		d.environ <- .ddg.where( cmd@vars.set , parent.env(parent.frame()) )
 
-      		if( d.environ == "undefined" )
-      		{
-      			d.environ <- globalenv()
-      		}
-      	}
+      		#if( d.environ == "undefined" )
+      		#{
+      		#	d.environ <- globalenv()
+      		#}
+      	#}
       }
+
       # Specifies whether or not a procedure node should be created
       # for this command. Basically, if a ddg exists and the
       # command is not a DDG command, it should be created.
@@ -2981,7 +2982,7 @@ ddg.MAX_HIST_LINES <- 2^14
         }
       }
      }
-
+    
      # Create a data node for each variable that might have been set in
      # something other than a simple assignment, with an edge from the
      # last node in the console block or source .
@@ -4502,10 +4503,10 @@ ddg.return.value <- function (expr=NULL, cmd.func=NULL) {
       {
       	env <- .ddg.where( var, parent.env(parent.frame()) )
 
-      	if( env == "undefined" )
-      	{
-      		env <- globalenv()
-      	}
+      	#if( env == "undefined" )
+      	#{
+      	#	env <- globalenv()
+      	#}
       }
       dscope <- .ddg.get.scope(var, env=env)
       .ddg.save.data(var, dvalue, scope=dscope)

--- a/examples-no-instrumentation/AssignFunctionTest/AssignFunctionTest.R
+++ b/examples-no-instrumentation/AssignFunctionTest/AssignFunctionTest.R
@@ -1,0 +1,137 @@
+# Assign Function Test
+# Tests the 'assign()' function
+#
+# @author Elizabeth Fong
+# @version September 2016
+
+
+# --- The assign() function -------------------------------------------- #
+
+# new variable in global environment
+assign( "a" , 0 , inherits = FALSE )
+stopifnot( a == 0 )
+
+assign( "b" , 0 , inherits = TRUE )
+stopifnot( b == 0 )
+
+
+# reassignment to existing variable in global environment
+assign( "a" , 1 , inherits = FALSE )
+stopifnot( a == 1 )
+
+assign( "b" , 1 , inherits = TRUE )
+stopifnot( b == 1 )
+
+
+# in a function environment: inherits = FALSE 
+fn1 <- function()
+{
+  assign( "d" , 0 , inherits = FALSE )
+  stopifnot( d == 0 )
+}
+
+fn1()
+stopifnot( ! exists("d") )
+
+
+# in a function environment: inherits = TRUE
+fn2 <- function()
+{
+  assign( "e" , 1 , inherits = TRUE )
+  stopifnot( e == 1 )
+}
+
+fn2()
+stopifnot( e == 1 )
+
+
+# nested function environment: inherits = FALSE
+fn3 <- function()
+{
+  f <- 0
+  
+  fn <- function()
+  {
+    assign( "f" , 1 , inherits = FALSE )
+    stopifnot( f == 1 )
+  }
+  
+  fn()
+  stopifnot( f == 0 )
+}
+
+fn3()
+stopifnot( ! exists("f") )
+
+
+# nested function environment: inherits = TRUE, existing variable
+fn4 <- function()
+{
+  g <- 0
+  
+  fn <- function()
+  {
+    assign( "g" , 1 , inherits = TRUE )
+  }
+  
+  fn()
+  stopifnot( g == 1 )
+}
+
+fn4()
+stopifnot( ! exists("g") )
+
+
+# nested function environment: inherits = TRUE, no existing variable
+fn5 <- function()
+{
+  fn <- function()
+  {
+    assign( "h" , 0 , inherits = TRUE )
+  }
+  
+  fn()
+}
+
+fn5()
+stopifnot( h == 0 )
+
+
+# in a new environment: inherits = FALSE
+env1 <- new.env()
+assign( "i" , 1 , envir = env1 , inherits = FALSE )
+
+stopifnot( env1$i == 1 )
+stopifnot( ! exists("i") )
+
+
+# in an environment: inherits = TRUE
+assign( "j" , 2 , envir = env1 , inherits = TRUE )
+
+stopifnot( ! exists("env1$j") )
+stopifnot( j == 2 )
+
+
+# in a nested environment: inherits = FALSE
+env1$env <- new.env( parent = env1 )
+assign( "k" , 3 , envir = env1$env , inherits = FALSE )
+
+stopifnot( env1$env$k == 3 )
+stopifnot( ! exists("env1$k") )
+stopifnot( ! exists("k") )
+
+
+# in a nested environment: inherits = TRUE, existing variable
+assign( "i" , 4 , envir = env1$env , inherits = TRUE )
+
+stopifnot( ! exists("env1$env$i") )
+stopifnot( env1$i == 4 )
+stopifnot( ! exists("i") )
+
+
+# in a nested environment: inherits = TRUE, no existing variable
+assign( "l" , 5 , envir = env1$env , inherits = TRUE )
+
+stopifnot( ! exists("env1$env$l") )
+stopifnot( ! exists("env1$l") )
+stopifnot( l == 5 )

--- a/examples-no-instrumentation/AssignmentOperatorsTest/AssignmentOperatorsTest.R
+++ b/examples-no-instrumentation/AssignmentOperatorsTest/AssignmentOperatorsTest.R
@@ -1,0 +1,185 @@
+# Assignment Operator Test
+# Tests the '=', '<-' and '<<-' operators
+#
+# @author Elizabeth Fong
+# @version September 2016
+
+
+# --- THE '=' OPERATOR ------------------------------------------------- #
+
+# new variable in global environment
+a = 1
+stopifnot( a == 1 )
+
+
+# reassignment to existing variable in global environment
+a = 2
+stopifnot( a == 2 )
+
+
+# in a function environment
+fn1 <- function()
+{
+  a = 3
+  stopifnot( a == 3 )
+}
+
+fn1()
+stopifnot( a == 2 )
+
+
+# nested function environment
+fn2 <- function()
+{
+  a = 4
+  
+  fn <- function()
+  {
+    a = 5
+  }
+  
+  fn()
+  stopifnot( a == 4 )
+}
+
+fn2()
+stopifnot( a == 2 )
+
+
+# in a new environment
+env1 <- new.env()
+env1$a = 6
+
+stopifnot( env1$a == 6 )
+stopifnot( a == 2 )
+
+
+# in a nested environment
+env1$env <- new.env( parent = env1 )
+env1$env$a = 7
+
+stopifnot( env1$env$a == 7 )
+stopifnot( env1$a == 6 )
+stopifnot( a == 2 )
+
+
+# --- THE '<-' OPERATOR ------------------------------------------------ #
+
+# new variable in global environment
+b <- 1
+stopifnot( b == 1 )
+
+# reassignment to existing variable in global environment
+b <- 2
+stopifnot( b == 2 )
+
+
+# in a function environment
+fn3 <- function()
+{
+  b <- 3
+  stopifnot( b == 3 )
+}
+
+fn3()
+stopifnot( b == 2 )
+
+
+# nested function environment
+fn4 <- function()
+{
+  b <- 4
+  
+  fn <- function()
+  {
+    b <- 5
+  }
+  
+  fn()
+  stopifnot( b == 4 )
+}
+
+fn4()
+stopifnot( b == 2 )
+
+
+# in a new environment
+env2 <- new.env()
+env2$b <- 6
+
+stopifnot( env2$b == 6 )
+stopifnot( b == 2 )
+
+
+# in a nested environment
+env2$env <- new.env( parent = env2 )
+env2$env$b <- 7
+
+stopifnot( env2$env$b == 7 )
+stopifnot( env2$b == 6 )
+stopifnot( b == 2 )
+
+
+# --- THE '<<-' OPERATOR ----------------------------------------------- #s
+
+# assignment in the global environment WILL FAIL!
+
+# in a function environment
+
+fn5 <- function()
+{
+  d <<- 1
+}
+
+fn5()
+stopifnot( d == 1 )
+
+
+# nested function environment - overriding exising variable
+fn6 <- function()
+{
+  e <- 0
+  
+  fn <- function()
+  {
+    e <<- 1
+  }
+  
+  fn()
+  stopifnot( e == 1 )
+}
+
+fn6()
+stopifnot( ! exists("e") )
+
+
+# nested function environment - no existing variable
+fn7 <- function()
+{
+  fn <- function()
+  {
+    f <<- 3
+  }
+  
+  fn()
+}
+
+fn7()
+stopifnot( f == 3 )
+
+
+# in a new environment - DOES NOT WORK!
+#env3 <- new.env()
+#env3$f <<- 4    # Error: object 'env3' not found
+#
+#stopifnot( f == 4 )
+#stopifnot( ! exists("env3$f") )
+#
+#
+# in a nested environment - DOES NOT WORK!
+#env3$env <- new.env( parent = env3 )
+#env3$env$f <<- 5    # Error: object 'env3' not found
+#
+#stopifnot( ! exists("env2$env$f") )
+#stopifnot( ! exists("env$f") )
+#stopifnot( f == 5 )


### PR DESCRIPTION
After scrutinising the code, I believe that the scoping issue is now fixed. 

However as part of the test cases, there is one case where it is still failing, which is the errors found when the `<<-` is used in conjunction with user-defined environments. The issue that addresses it is [#190](https://github.com/End-to-end-provenance/RDataTracker/issues/190).