### PR TITLE
No more CRAN check (as it does not seem anyone plan to make it work), run `ant -file tests.xml test-all`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,10 @@ r_packages:
 r_github_packages:
   - jimhester/lintr
 
+script:
+  - R CMD build .
+  - R CMD check *tar.gz
+
 after_success:
   - Rscript -e 'lintr::lint_package()'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ r_github_packages:
 script:
   - R CMD build .
   - R CMD check *tar.gz
+  - ant -file build.xml install
   - ant -file tests.xml basicTest
   - ant -file tests.xml test-all
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,6 @@ r_packages:
   - sysfonts
   - extrafont
 
-r_github_packages:
-  - jimhester/lintr
-
 script:
   - R CMD build .
   - R CMD check *tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     packages:
       libicu-dev
       libfreetype6-dev
+      ant
       r-cran-chron
       r-cran-zoo
       r-cran-shiny
@@ -50,6 +51,8 @@ r_github_packages:
 script:
   - R CMD build .
   - R CMD check *tar.gz
+  - ant -file tests.xml basicTest
+  - ant -file tests.xml test-all
 
 after_success:
   - Rscript -e 'lintr::lint_package()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,5 @@ script:
   - ant -file tests.xml basicTest
   - ant -file tests.xml test-all
 
-after_success:
-  - Rscript -e 'lintr::lint_package()'
-
 notifications:
   slack: endtoendprovenance:WxevOs6n66eZRbCn9HcW2mGD

--- a/tests/depends.r
+++ b/tests/depends.r
@@ -30,10 +30,9 @@ installFonts <- function() {
 }
 
 # List of packages that are needed
-#pkgs <- c("RDataTracker", "chron", "gWidgets", "dplR", "zoo", "ggplot2",
-#		"gdata", "grid", "gridExtra", "mgcv", "akima", "spatstat", "reshape2", "RCurl", "plyr",
-#    "xkcd", "sysfonts", "extrafont")
-pkgs <- c("RDataTracker")
+pkgs <- c("RDataTracker", "chron", "gWidgets", "dplR", "zoo", "ggplot2",
+		"gdata", "grid", "gridExtra", "mgcv", "akima", "spatstat", "reshape2", "RCurl", "plyr",
+    "xkcd", "sysfonts", "extrafont")
 
 # Install the packages that might be missing
 if (all(unlist(Map(usePackage, pkgs))))  print("All required packages installed.")


### PR DESCRIPTION
Travis has been modified to  not run CRAN check (so will not fell because the package does not meet CRAN standards).

It now runs the following:
```
- R CMD build .
  - R CMD check *tar.gz
  - ant -file build.xml install
  - ant -file tests.xml basicTest
  - ant -file tests.xml test-all
```

Ready to be merged as far travis test is concerned.

However, not that tests.xml usefulness in this context is limited, as the failure on test condition not being met does not seem to be implemented.

Extract of output:
```
basicTest:
run-regression-test:
run-test:
    [mkdir] Created dir: /home/travis/build/tfjmp/RDataTracker/tests/basicTest/local
     [copy] Copying 1 file to /home/travis/build/tfjmp/RDataTracker/tests/basicTest
     [exec] Result: 1
     [copy] Copying 4 files to /home/travis/build/tfjmp/RDataTracker/tests/basicTest/local
     [echo] 
     [echo]       Diff of (1) basicTest.out.local and (2) expected_basicTest.out.local:
     [echo]     
     [exec] 0a1
     [exec] > Error in FUN(newX[, i], ...) : invalid 'type' (character) of argument
     [exec] 3,4d3
     [exec] < This website may be helpful:
     [exec] < Error in FUN(newX[, i], ...) : invalid 'type' (character) of argument
     [exec] 5a5,8
     [exec] > In addition: Warning message:
     [exec] > For the statement "storage.mode(z) <- a", in line NA,
     [exec] > This website may be helpful:
     [exec] > The type changed for the following variables: z 
     [exec] Result: 1
     [echo] 
     [echo]       Diff of (1) ddg.json.local and (2) expected_basicTest_ddg.json.local:
     [echo]     
     [exec] 474,481c474
     [exec] <   {"package" : "base", "version" : "3.4.0"},
     [exec] <   {"package" : "datasets", "version" : "3.4.0"},
     [exec] <   {"package" : "graphics", "version" : "3.4.0"},
     [exec] <   {"package" : "grDevices", "version" : "3.4.0"},
     [exec] <   {"package" : "methods", "version" : "3.4.0"},
     [exec] <   {"package" : "RDataTracker", "version" : "2.26.1"},
     [exec] <   {"package" : "stats", "version" : "3.4.0"},
     [exec] <   {"package" : "utils", "version" : "3.4.0"}]
     [exec] ---
     [exec] >   {"package" : "RDataTracker", "version" : "2.26.1"}]
     [exec] Result: 1
BUILD SUCCESSFUL
Total time: 4 seconds
```

Is it really successful?
