### PR TITLE
Annotate func on off

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -7,10 +7,10 @@ export(ddg.breakpoint, ddg.set.breakpoint, ddg.list.breakpoints, ddg.clear.break
 export(ddg.flush.ddg)
 export(ddg.source)
 export(ddg.forloop, ddg.first.loop, ddg.max.loops, ddg.loop.count, ddg.loop.count.inc, ddg.reset.loop.count)
-export(ddg.loop.annotate, ddg.loop.annotate.on, ddg.loop.annotate.off)
-export(ddg.annotate.inside, ddg.max.snapshot.size, ddg.details.omitted, ddg.should.run.annotated)
+export(ddg.loop.annotate.on, ddg.loop.annotate.off)
+export(ddg.max.snapshot.size, ddg.details.omitted, ddg.should.run.annotated)
 export(ddg.set.detail, ddg.get.detail, ddg.clear.detail)
-export(ddg.inside.loop, ddg.set.inside.loop, ddg.not.inside.loop)
+export(ddg.set.inside.loop, ddg.not.inside.loop)
 
 importFrom(gtools, defmacro)
 importFrom(XML, saveXML)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -8,7 +8,7 @@ export(ddg.flush.ddg)
 export(ddg.source)
 export(ddg.forloop, ddg.first.loop, ddg.max.loops, ddg.loop.count, ddg.loop.count.inc, ddg.reset.loop.count)
 export(ddg.loop.annotate, ddg.loop.annotate.on, ddg.loop.annotate.off)
-export(ddg.annotate.inside, ddg.max.snapshot.size, ddg.details.omitted)
+export(ddg.annotate.inside, ddg.max.snapshot.size, ddg.details.omitted, ddg.should.run.annotated)
 export(ddg.set.detail, ddg.get.detail, ddg.clear.detail)
 export(ddg.inside.loop, ddg.set.inside.loop, ddg.not.inside.loop)
 

--- a/R/DDGStatement.R
+++ b/R/DDGStatement.R
@@ -460,12 +460,7 @@ null.pos <- function() {
     # Note that this will not annotate anonymous functions, like ones that might be passed to lapply, for example
     # Is that what we want?
   if (.ddg.is.assign(parsed.command) && .ddg.is.functiondecl(parsed.command[[3]])) {
-#    if (ddg.annotate.inside()) {
-      return(.ddg.add.function.annotations(command))
-#    }
-#    else {
-#      return(command@parsed)
-#    }
+    return(.ddg.add.function.annotations(command))
   }
   
   statement.type <- as.character(.ddg.get.statement.type(parsed.command))
@@ -509,13 +504,8 @@ null.pos <- function() {
 
   # Function declaration
   if (.ddg.is.assign(parsed.cmd) && .ddg.is.functiondecl(parsed.cmd[[3]])) {
-    #if (ddg.annotate.inside()) {
-      # Create the DDGStatement objects for the statements in the function
-      return (.ddg.parse.contained.function(cmd, script.name, parseData, parsed.cmd[[3]][[3]]))
-    #}
-    #else {
-     # return (list())
-    #}
+    # Create the DDGStatement objects for the statements in the function
+    return (.ddg.parse.contained.function(cmd, script.name, parseData, parsed.cmd[[3]][[3]]))
   }
   
   # Check if we want to go inside loop and if-statements
@@ -656,61 +646,45 @@ null.pos <- function() {
   # Get function name.
   func.name <- toString(parsed.function.decl[[2]])
   #print(paste("Annotating", func.name))
-  #print(paste("length(function.decl@contained) =", length(function.decl@contained)))
 
-  # Return if a list of functions to annotate is provided and this
-  # function is not on the list.
-  #if (!is.null(.ddg.annotate.on()) & !(func.name %in% .ddg.annotate.on())) return(parsed.function.decl)
+  # Get function definition.
+  func.definition <- parsed.function.decl[[3]]
 
-  # Return if a list of functions not to annotate is provided and this
-  # function is on the list.
-  #else if (!is.null(.ddg.annotate.off()) & func.name %in% .ddg.annotate.off()) return(parsed.function.decl)
+  # Create function block if necessary.
+  if (func.definition[[3]][[1]] != "{") {
+    func.definition <- .ddg.create.function.block(func.definition)
+  }
 
-  # Add function annotations.
-  #else {
-    # Get function definition.
-    func.definition <- parsed.function.decl[[3]]
+  # Create new function body with an if-then statement for annotations.
+  func.definition <- .ddg.add.conditional.statement(func.definition, func.name)
 
-    # Create function block if necessary.
-    if (func.definition[[3]][[1]] != "{") {
-      func.definition <- .ddg.create.function.block(func.definition)
-    }
+  # Insert call to ddg.function if not already added.
+  if (!.ddg.has.call.to(func.definition[[3]], "ddg.function")) {
+    func.definition <- .ddg.insert.ddg.function(func.definition)
+  }
 
-    # Create new function body with an if-then statement for annotations.
-    func.definition <- .ddg.add.conditional.statement(func.definition, func.name)
+  # Insert calls to ddg.return.value if not already added.
+  if (!.ddg.has.call.to(func.definition[[3]], "ddg.return.value")) {
+    func.definition <- .ddg.wrap.all.return.parameters(func.definition, function.decl@contained)
+  }
 
-    # Insert call to ddg.function if not already added.
-    if (!.ddg.has.call.to(func.definition[[3]], "ddg.function")) {
-      #print("Adding ddg.function call")
-      func.definition <- .ddg.insert.ddg.function(func.definition)
-    }
+  # Wrap last statement with ddg.return.value if not already added
+  # and if last statement is not a simple return or a ddg function.
+  last.statement <- .ddg.find.last.statement(func.definition)
+  if (!.ddg.is.call.to(last.statement, "ddg.return.value") & !.ddg.is.call.to(last.statement, "return") & !.ddg.is.call.to.ddg.function(last.statement)) {
+    func.definition <- .ddg.wrap.last.line(func.definition, function.decl@contained)
+  }
 
-    # Insert calls to ddg.return.value if not already added.
-    if (!.ddg.has.call.to(func.definition[[3]], "ddg.return.value")) {
-      #print("Wrapping all return parameters")
-      func.definition <- .ddg.wrap.all.return.parameters(func.definition, function.decl@contained)
-    }
+  # Wrap statements with ddg.eval if not already added and if
+  # statements are not calls to a ddg function and do not contain
+  # ddg.return.value.
+  if (!.ddg.has.call.to(func.definition, "ddg.eval")) {
+    func.definition <- .ddg.wrap.with.ddg.eval(func.definition, function.decl@contained)
+  }
 
-    # Wrap last statement with ddg.return.value if not already added
-    # and if last statement is not a simple return or a ddg function.
-    last.statement <- .ddg.find.last.statement(func.definition)
-    if (!.ddg.is.call.to(last.statement, "ddg.return.value") & !.ddg.is.call.to(last.statement, "return") & !.ddg.is.call.to.ddg.function(last.statement)) {
-      #print("Wrapping last line")
-      func.definition <- .ddg.wrap.last.line(func.definition, function.decl@contained)
-    }
-
-    # Wrap statements with ddg.eval if not already added and if
-    # statements are not calls to a ddg function and do not contain
-    # ddg.return.value.
-    if (!.ddg.has.call.to(func.definition, "ddg.eval")) {
-      #print("Adding ddg.eval calls")
-      func.definition <- .ddg.wrap.with.ddg.eval(func.definition, function.decl@contained)
-    }
-
-    # Reassemble parsed.command.
-    #print(paste("Done annotating", func.name))
-    return (as.expression (call ("<-", as.name(func.name), func.definition)))
-  #}
+  # Reassemble parsed.command.
+  #print(paste("Done annotating", func.name))
+  return (as.expression (call ("<-", as.name(func.name), func.definition)))
 }
 
 # .ddg.create.function.block creates a function block.
@@ -739,7 +713,6 @@ null.pos <- function() {
 # func.definition - original function definition.
 
 .ddg.add.conditional.statement <- function(func.definition, func.name) {
-  #print(paste("Adding if statement to", func.name))
   # Get the function parameters.
   func.params <- func.definition[[2]]
 
@@ -753,7 +726,6 @@ null.pos <- function() {
   # functions that are inside control structures when we 
   # are not collecting provenance in control structures.
   new.func.body.txt <-
-#    c(paste("if ((ddg.loop.annotate() || ddg.inside.loop() == 0) && ddg.should.run.annotated(\"", func.name, "\")) {", sep=""),
     c(paste("if (ddg.should.run.annotated(\"", func.name, "\")) {", sep=""),
     as.list(func.body[2:pos]),
     paste("} else {", sep=""),
@@ -937,8 +909,6 @@ null.pos <- function() {
   pos <- length(block)
 
   last.statement <- block[[pos]]
-  #print(paste(".ddg.wrap.last.line: parsed.stmts =", deparse(parsed.stmts)))
-  #print(paste("length(parsed.stmts) =", length(parsed.stmts)))
   parsed.stmt <- parsed.stmts[[length(parsed.stmts)]]
 
   wrapped.statement <- .ddg.create.ddg.return.call(last.statement, parsed.stmt)

--- a/R/DDGStatement.R
+++ b/R/DDGStatement.R
@@ -655,8 +655,8 @@ null.pos <- function() {
 
   # Get function name.
   func.name <- toString(parsed.function.decl[[2]])
-  print(paste("Annotating", func.name))
-  print(paste("length(function.decl@contained) =", length(function.decl@contained)))
+  #print(paste("Annotating", func.name))
+  #print(paste("length(function.decl@contained) =", length(function.decl@contained)))
 
   # Return if a list of functions to annotate is provided and this
   # function is not on the list.
@@ -681,13 +681,13 @@ null.pos <- function() {
 
     # Insert call to ddg.function if not already added.
     if (!.ddg.has.call.to(func.definition[[3]], "ddg.function")) {
-      print("Adding ddg.function call")
+      #print("Adding ddg.function call")
       func.definition <- .ddg.insert.ddg.function(func.definition)
     }
 
     # Insert calls to ddg.return.value if not already added.
     if (!.ddg.has.call.to(func.definition[[3]], "ddg.return.value")) {
-      print("Wrapping all return parameters")
+      #print("Wrapping all return parameters")
       func.definition <- .ddg.wrap.all.return.parameters(func.definition, function.decl@contained)
     }
 
@@ -695,7 +695,7 @@ null.pos <- function() {
     # and if last statement is not a simple return or a ddg function.
     last.statement <- .ddg.find.last.statement(func.definition)
     if (!.ddg.is.call.to(last.statement, "ddg.return.value") & !.ddg.is.call.to(last.statement, "return") & !.ddg.is.call.to.ddg.function(last.statement)) {
-      print("Wrapping last line")
+      #print("Wrapping last line")
       func.definition <- .ddg.wrap.last.line(func.definition, function.decl@contained)
     }
 
@@ -703,12 +703,12 @@ null.pos <- function() {
     # statements are not calls to a ddg function and do not contain
     # ddg.return.value.
     if (!.ddg.has.call.to(func.definition, "ddg.eval")) {
-      print("Adding ddg.eval calls")
+      #print("Adding ddg.eval calls")
       func.definition <- .ddg.wrap.with.ddg.eval(func.definition, function.decl@contained)
     }
 
     # Reassemble parsed.command.
-    print(paste("Done annotating", func.name))
+    #print(paste("Done annotating", func.name))
     return (as.expression (call ("<-", as.name(func.name), func.definition)))
   #}
 }
@@ -739,7 +739,7 @@ null.pos <- function() {
 # func.definition - original function definition.
 
 .ddg.add.conditional.statement <- function(func.definition, func.name) {
-  print(paste("Adding if statement to", func.name))
+  #print(paste("Adding if statement to", func.name))
   # Get the function parameters.
   func.params <- func.definition[[2]]
 
@@ -937,8 +937,8 @@ null.pos <- function() {
   pos <- length(block)
 
   last.statement <- block[[pos]]
-  print(paste(".ddg.wrap.last.line: parsed.stmts =", deparse(parsed.stmts)))
-  print(paste("length(parsed.stmts) =", length(parsed.stmts)))
+  #print(paste(".ddg.wrap.last.line: parsed.stmts =", deparse(parsed.stmts)))
+  #print(paste("length(parsed.stmts) =", length(parsed.stmts)))
   parsed.stmt <- parsed.stmts[[length(parsed.stmts)]]
 
   wrapped.statement <- .ddg.create.ddg.return.call(last.statement, parsed.stmt)

--- a/R/RDataTracker.R
+++ b/R/RDataTracker.R
@@ -3047,7 +3047,7 @@ ddg.MAX_HIST_LINES <- 2^14
       # block, so there is no need to create additional nodes for the
       # control statement itself.
 
-      create <- !cmd@isDdgFunc && .ddg.is.init() && .ddg.enable.console() && !(control.statement && ddg.annotate.inside() && ddg.max.loops() > 0)
+      create <- !cmd@isDdgFunc && .ddg.is.init() && .ddg.enable.console() && !(control.statement && .ddg.annotate.inside() && ddg.max.loops() > 0)
       # create <- !cmd@isDdgFunc && .ddg.is.init() && .ddg.enable.console()
       start.finish.created <- FALSE
       cur.cmd.closed <- FALSE
@@ -4380,21 +4380,6 @@ ddg.MAX_HIST_LINES <- 2^14
 .ddg.is.local <- function(name, scope) {
   return(exists(name, scope, inherits=FALSE))
 }
-
-#.ddg.rm removes all data except ddg information
-.ddg.rm <-function()
-
-# .ddg.get.annotation.list checks to see if the script contains calls to
-# ddg.annotate.on or ddg.annotate.off. If it does, these calls are executed.
-# No longer used
-
-#.ddg.get.annotation.list <- function(parsed.command) {
-#  if (length(parsed.command[[1]]) > 1) {
-#    if (toString(parsed.command[[1]][[1]]) == "ddg.annotate.on" | toString(parsed.command[[1]][[1]]) == "ddg.annotate.off") {
-#      eval(parsed.command)
-#    }
-#  }
-#}
 
 # Creates a start node for the current command if one has not
 # been created already.

--- a/man/InitSave.Rd
+++ b/man/InitSave.Rd
@@ -4,7 +4,6 @@
 \alias{ddg.set.detail}
 \alias{ddg.get.detail}
 \alias{ddg.clear.detail}
-\alias{ddg.annotate.inside}
 \alias{ddg.max.loops}
 \alias{ddg.max.snapshot.size}
 \alias{ddg.annotate.on}
@@ -20,11 +19,9 @@
 \alias{ddg.loop.count}
 \alias{ddg.loop.count.inc}
 \alias{ddg.reset.loop.count}
-\alias{ddg.loop.annotate}
 \alias{ddg.loop.annotate.on}
 \alias{ddg.loop.annotate.off}
 \alias{ddg.details.omitted}
-\alias{ddg.inside.loop}
 \alias{ddg.set.inside.loop}
 \alias{ddg.not.inside.loop}
 \title{Creating Provenance Graphs with RDataTracker}
@@ -39,7 +36,6 @@ ddg.run(r.script.path = NULL, ddgdir = NULL, overwrite = TRUE, f = NULL, enable.
 ddg.set.detail(detail.level)
 ddg.get.detail()
 ddg.clear.detail()
-ddg.annotate.inside()
 ddg.max.loops()
 ddg.max.snapshot.size()
 ddg.annotate.on(fnames = NULL)
@@ -58,7 +54,6 @@ ddg.loop.annotate()
 ddg.loop.annotate.on()
 ddg.loop.annotate.off()
 ddg.details.omitted()
-ddg.inside.loop()
 ddg.not.inside.loop()
 ddg.set.inside.loop()
 }
@@ -130,7 +125,7 @@ ddg.set.inside.loop()
   max.snapshot.size passed to ddg.run are used instead.  The current level of detail is returned by
   ddg.get.detail and reset to NULL by ddg.clear.detail.
   
-  ddg.annotate.inside returns the current value of annotate.inside.  ddg.max.loops returns the current
+  ddg.max.loops returns the current
   value of max.loops.  ddg.max.snapshot.size returns the current value of max.snapshot.size.
   
   ddg.console.on and ddg.console.off toggle the console parameter for DDG creation. 
@@ -149,7 +144,7 @@ ddg.set.inside.loop()
   the function returns "DDG not available".
   
   ddg.should.run.annotated, ddg.forloop, ddg.first.loop, ddg.loop.count, ddg.loop.count.inc, ddg.reset.loop.count, 
-  ddg.loop.annotate, ddg.loop.annotate.on, ddg.loop.annotate.off, ddg.details.omitted, ddg.inside.loop, 
+  ddg.loop.annotate.on, ddg.loop.annotate.off, ddg.details.omitted, 
   ddg.not.inside.loop, and ddg.set.inside.loop are used internally by RDataTracker--do not use.
 }
 \author{Emery Boose and Barbara Lerner}

--- a/man/InitSave.Rd
+++ b/man/InitSave.Rd
@@ -9,6 +9,7 @@
 \alias{ddg.max.snapshot.size}
 \alias{ddg.annotate.on}
 \alias{ddg.annotate.off}
+\alias{ddg.should.run.annotated}
 \alias{ddg.save}
 \alias{ddg.flush.ddg}
 \alias{ddg.console.off}
@@ -43,6 +44,7 @@ ddg.max.loops()
 ddg.max.snapshot.size()
 ddg.annotate.on(fnames = NULL)
 ddg.annotate.off(fnames = NULL)
+ddg.should.run.annotated(func.name)
 ddg.console.on()
 ddg.console.off()
 ddg.flush.ddg(ddg.path = NULL)
@@ -80,6 +82,7 @@ ddg.set.inside.loop()
   \item{f}{ A function to run.  Data provenance is collected within the function. }
   \item{detail.level}{ An integer indicating the level of provenance detail to be collected. }
   \item{fnames}{ A list of one or more function names. }
+  \item{func.name}{A function name passed as a string.}
   \item{quit}{ If TRUE, all DDG files are removed from memory. }
   \item{ddg.path}{ The path to the DDG directory which needs to be flushed. }
   \item{index.var}{ The index variable passed to ddg.forloop. }
@@ -145,9 +148,9 @@ ddg.set.inside.loop()
   and loads the most recent ddg.txt file (if any). If the DDG path is not set or a ddg.txt file is not available,
   the function returns "DDG not available".
   
-  ddg.forloop, ddg.first.loop, ddg.loop.count, ddg.loop.count.inc, ddg.reset.loop.count, ddg.loop.annotate,
-  ddg.loop.annotate.on, ddg.loop.annotate.off, ddg.details.omitted, ddg.inside.loop, ddg.not.inside.loop, and
-  ddg.set.inside.loop are used internally by RDataTracker--do not use.
+  ddg.should.run.annotated, ddg.forloop, ddg.first.loop, ddg.loop.count, ddg.loop.count.inc, ddg.reset.loop.count, 
+  ddg.loop.annotate, ddg.loop.annotate.on, ddg.loop.annotate.off, ddg.details.omitted, ddg.inside.loop, 
+  ddg.not.inside.loop, and ddg.set.inside.loop are used internally by RDataTracker--do not use.
 }
 \author{Emery Boose and Barbara Lerner}
 \examples{

--- a/tests/SourceFuncTest/expected_SourceFuncTest.out
+++ b/tests/SourceFuncTest/expected_SourceFuncTest.out
@@ -1,1 +1,1 @@
-Execution Time = 0.858454
+Execution Time = 0.83582

--- a/tests/SourceFuncTest/expected_SourceFuncTest_ddg.json
+++ b/tests/SourceFuncTest/expected_SourceFuncTest_ddg.json
@@ -9,7 +9,7 @@
 "p1" : {
 "rdt:name" : "SourceFuncTest.R",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.03",
+"rdt:elapsedTime" : "0.0429999999999999",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -20,7 +20,7 @@
 "p2" : {
 "rdt:name" : "fun <- function(a, b) {    return(a + b)}",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.03",
+"rdt:elapsedTime" : "0.0449999999999999",
 "rdt:scriptNum" : "0",
 "rdt:startLine" : "3",
 "rdt:startCol" : "1",
@@ -31,7 +31,7 @@
 "p3" : {
 "rdt:name" : "x <- 6",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.05",
+"rdt:elapsedTime" : "0.0509999999999999",
 "rdt:scriptNum" : "0",
 "rdt:startLine" : "7",
 "rdt:startCol" : "1",
@@ -42,7 +42,7 @@
 "p4" : {
 "rdt:name" : "y <- 10",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.05",
+"rdt:elapsedTime" : "0.0579999999999999",
 "rdt:scriptNum" : "0",
 "rdt:startLine" : "8",
 "rdt:startCol" : "1",
@@ -53,7 +53,7 @@
 "p5" : {
 "rdt:name" : "z <- fun(x, y)",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.0599999999999999",
+"rdt:elapsedTime" : "0.0639999999999999",
 "rdt:scriptNum" : "0",
 "rdt:startLine" : "9",
 "rdt:startCol" : "1",
@@ -64,7 +64,7 @@
 "p6" : {
 "rdt:name" : "fun(x, y)",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.0599999999999999",
+"rdt:elapsedTime" : "0.077",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -75,7 +75,7 @@
 "p7" : {
 "rdt:name" : "a  <-  x",
 "rdt:type" : "Binding",
-"rdt:elapsedTime" : "0.0599999999999999",
+"rdt:elapsedTime" : "0.078",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -86,7 +86,7 @@
 "p8" : {
 "rdt:name" : "b  <-  y",
 "rdt:type" : "Binding",
-"rdt:elapsedTime" : "0.08",
+"rdt:elapsedTime" : "0.087",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -97,7 +97,7 @@
 "p9" : {
 "rdt:name" : "fun",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.08",
+"rdt:elapsedTime" : "0.095",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -108,7 +108,7 @@
 "p10" : {
 "rdt:name" : "return(a + b)",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.09",
+"rdt:elapsedTime" : "0.111",
 "rdt:scriptNum" : "0",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -119,7 +119,7 @@
 "p11" : {
 "rdt:name" : "fun(x, y)",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.11",
+"rdt:elapsedTime" : "0.124",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -130,7 +130,7 @@
 "p12" : {
 "rdt:name" : "z <- fun(x, y)",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.11",
+"rdt:elapsedTime" : "0.125",
 "rdt:scriptNum" : "0",
 "rdt:startLine" : "9",
 "rdt:startCol" : "1",
@@ -141,7 +141,7 @@
 "p13" : {
 "rdt:name" : "source1.r",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.11",
+"rdt:elapsedTime" : "0.139",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -152,7 +152,7 @@
 "p14" : {
 "rdt:name" : "w <- z + x",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.11",
+"rdt:elapsedTime" : "0.14",
 "rdt:scriptNum" : "1",
 "rdt:startLine" : "3",
 "rdt:startCol" : "1",
@@ -163,7 +163,7 @@
 "p15" : {
 "rdt:name" : "w <- fun(w, y)",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.13",
+"rdt:elapsedTime" : "0.153",
 "rdt:scriptNum" : "1",
 "rdt:startLine" : "4",
 "rdt:startCol" : "1",
@@ -174,7 +174,7 @@
 "p16" : {
 "rdt:name" : "fun(w, y)",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.14",
+"rdt:elapsedTime" : "0.166",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -185,7 +185,7 @@
 "p17" : {
 "rdt:name" : "a  <-  w",
 "rdt:type" : "Binding",
-"rdt:elapsedTime" : "0.14",
+"rdt:elapsedTime" : "0.167",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -196,7 +196,7 @@
 "p18" : {
 "rdt:name" : "b  <-  y",
 "rdt:type" : "Binding",
-"rdt:elapsedTime" : "0.14",
+"rdt:elapsedTime" : "0.175",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -207,7 +207,7 @@
 "p19" : {
 "rdt:name" : "fun",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.16",
+"rdt:elapsedTime" : "0.183",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -218,7 +218,7 @@
 "p20" : {
 "rdt:name" : "return(a + b)",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.17",
+"rdt:elapsedTime" : "0.198",
 "rdt:scriptNum" : "0",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -229,7 +229,7 @@
 "p21" : {
 "rdt:name" : "fun(w, y)",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.17",
+"rdt:elapsedTime" : "0.211",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -240,7 +240,7 @@
 "p22" : {
 "rdt:name" : "w <- fun(w, y)",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.17",
+"rdt:elapsedTime" : "0.212",
 "rdt:scriptNum" : "1",
 "rdt:startLine" : "4",
 "rdt:startCol" : "1",
@@ -251,7 +251,7 @@
 "p23" : {
 "rdt:name" : "z <- 0",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.19",
+"rdt:elapsedTime" : "0.216",
 "rdt:scriptNum" : "1",
 "rdt:startLine" : "7",
 "rdt:startCol" : "1",
@@ -262,7 +262,7 @@
 "p24" : {
 "rdt:name" : "source1.r",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.19",
+"rdt:elapsedTime" : "0.223",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -273,7 +273,7 @@
 "p25" : {
 "rdt:name" : "source(\"source1.r\")",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.19",
+"rdt:elapsedTime" : "0.223",
 "rdt:scriptNum" : "0",
 "rdt:startLine" : "12",
 "rdt:startCol" : "1",
@@ -284,7 +284,7 @@
 "p26" : {
 "rdt:name" : "v <- fun(w, z)",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.2",
+"rdt:elapsedTime" : "0.233",
 "rdt:scriptNum" : "0",
 "rdt:startLine" : "15",
 "rdt:startCol" : "1",
@@ -295,7 +295,7 @@
 "p27" : {
 "rdt:name" : "fun(w, z)",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.2",
+"rdt:elapsedTime" : "0.245",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -306,7 +306,7 @@
 "p28" : {
 "rdt:name" : "a  <-  w",
 "rdt:type" : "Binding",
-"rdt:elapsedTime" : "0.2",
+"rdt:elapsedTime" : "0.246",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -317,7 +317,7 @@
 "p29" : {
 "rdt:name" : "b  <-  z",
 "rdt:type" : "Binding",
-"rdt:elapsedTime" : "0.22",
+"rdt:elapsedTime" : "0.255",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -328,7 +328,7 @@
 "p30" : {
 "rdt:name" : "fun",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.22",
+"rdt:elapsedTime" : "0.262",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -339,7 +339,7 @@
 "p31" : {
 "rdt:name" : "return(a + b)",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.24",
+"rdt:elapsedTime" : "0.277",
 "rdt:scriptNum" : "0",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -350,7 +350,7 @@
 "p32" : {
 "rdt:name" : "fun(w, z)",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.25",
+"rdt:elapsedTime" : "0.289",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -361,7 +361,7 @@
 "p33" : {
 "rdt:name" : "v <- fun(w, z)",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.25",
+"rdt:elapsedTime" : "0.29",
 "rdt:scriptNum" : "0",
 "rdt:startLine" : "15",
 "rdt:startCol" : "1",
@@ -372,7 +372,7 @@
 "p34" : {
 "rdt:name" : "source2.r",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.27",
+"rdt:elapsedTime" : "0.315",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -383,7 +383,7 @@
 "p35" : {
 "rdt:name" : "a <- 10",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.28",
+"rdt:elapsedTime" : "0.316",
 "rdt:scriptNum" : "2",
 "rdt:startLine" : "8",
 "rdt:startCol" : "1",
@@ -394,7 +394,7 @@
 "p36" : {
 "rdt:name" : "c <- 100",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.28",
+"rdt:elapsedTime" : "0.322",
 "rdt:scriptNum" : "2",
 "rdt:startLine" : "9",
 "rdt:startCol" : "1",
@@ -405,7 +405,7 @@
 "p37" : {
 "rdt:name" : "b <- a + c",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.28",
+"rdt:elapsedTime" : "0.327",
 "rdt:scriptNum" : "2",
 "rdt:startLine" : "12",
 "rdt:startCol" : "1",
@@ -416,7 +416,7 @@
 "p38" : {
 "rdt:name" : "a <- 20",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.3",
+"rdt:elapsedTime" : "0.338",
 "rdt:scriptNum" : "2",
 "rdt:startLine" : "13",
 "rdt:startCol" : "1",
@@ -427,7 +427,7 @@
 "p39" : {
 "rdt:name" : "source2.r",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.3",
+"rdt:elapsedTime" : "0.342",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -438,7 +438,7 @@
 "p40" : {
 "rdt:name" : "source(\"source2.r\")",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.3",
+"rdt:elapsedTime" : "0.343",
 "rdt:scriptNum" : "0",
 "rdt:startLine" : "18",
 "rdt:startCol" : "1",
@@ -449,7 +449,7 @@
 "p41" : {
 "rdt:name" : "source3.r",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.34",
+"rdt:elapsedTime" : "0.381",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -460,7 +460,7 @@
 "p42" : {
 "rdt:name" : "f <- function(x) {    g(x)    h(x)    return(1)}",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.36",
+"rdt:elapsedTime" : "0.382",
 "rdt:scriptNum" : "3",
 "rdt:startLine" : "1",
 "rdt:startCol" : "1",
@@ -469,53 +469,53 @@
 } ,
 
 "p43" : {
-"rdt:name" : "g <- function(x) {    ddg.function()    return(ddg.return.va",
+"rdt:name" : "g <- function(x) {    return(1)}",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.36",
+"rdt:elapsedTime" : "0.386",
 "rdt:scriptNum" : "3",
 "rdt:startLine" : "7",
 "rdt:startCol" : "1",
-"rdt:endLine" : "10",
+"rdt:endLine" : "9",
 "rdt:endCol" : "1"
 } ,
 
 "p44" : {
-"rdt:name" : "h <- function(x) {    ddg.function()    return(ddg.return.va",
+"rdt:name" : "h <- function(x) {    return(1)}",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.36",
+"rdt:elapsedTime" : "0.392",
 "rdt:scriptNum" : "3",
-"rdt:startLine" : "12",
+"rdt:startLine" : "11",
 "rdt:startCol" : "1",
-"rdt:endLine" : "15",
+"rdt:endLine" : "13",
 "rdt:endCol" : "1"
 } ,
 
 "p45" : {
 "rdt:name" : "someVector <- function() {    return(c(1, 3, 5))}",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.36",
+"rdt:elapsedTime" : "0.396",
 "rdt:scriptNum" : "3",
-"rdt:startLine" : "17",
+"rdt:startLine" : "15",
 "rdt:startCol" : "1",
-"rdt:endLine" : "19",
+"rdt:endLine" : "17",
 "rdt:endCol" : "1"
 } ,
 
 "p46" : {
 "rdt:name" : "x <- 10",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.38",
+"rdt:elapsedTime" : "0.4",
 "rdt:scriptNum" : "3",
-"rdt:startLine" : "23",
+"rdt:startLine" : "21",
 "rdt:startCol" : "1",
-"rdt:endLine" : "23",
+"rdt:endLine" : "21",
 "rdt:endCol" : "7"
 } ,
 
 "p47" : {
 "rdt:name" : "f(x)",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.38",
+"rdt:elapsedTime" : "0.405",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -526,7 +526,7 @@
 "p48" : {
 "rdt:name" : "x  <-  x",
 "rdt:type" : "Binding",
-"rdt:elapsedTime" : "0.38",
+"rdt:elapsedTime" : "0.407",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -537,7 +537,7 @@
 "p49" : {
 "rdt:name" : "f",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.39",
+"rdt:elapsedTime" : "0.412",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -548,7 +548,7 @@
 "p50" : {
 "rdt:name" : "g(x)",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.39",
+"rdt:elapsedTime" : "0.42",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -559,7 +559,7 @@
 "p51" : {
 "rdt:name" : "x  <-  x",
 "rdt:type" : "Binding",
-"rdt:elapsedTime" : "0.39",
+"rdt:elapsedTime" : "0.42",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -570,7 +570,7 @@
 "p52" : {
 "rdt:name" : "g",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.39",
+"rdt:elapsedTime" : "0.428",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -581,18 +581,18 @@
 "p53" : {
 "rdt:name" : "return(1)",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.41",
-"rdt:scriptNum" : "-1",
-"rdt:startLine" : "-1",
-"rdt:startCol" : "-1",
-"rdt:endLine" : "-1",
-"rdt:endCol" : "-1"
+"rdt:elapsedTime" : "0.437",
+"rdt:scriptNum" : "3",
+"rdt:startLine" : "8",
+"rdt:startCol" : "3",
+"rdt:endLine" : "8",
+"rdt:endCol" : "11"
 } ,
 
 "p54" : {
 "rdt:name" : "g(x)",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.41",
+"rdt:elapsedTime" : "0.443",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -603,7 +603,7 @@
 "p55" : {
 "rdt:name" : "g(x)",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.41",
+"rdt:elapsedTime" : "0.444",
 "rdt:scriptNum" : "3",
 "rdt:startLine" : "2",
 "rdt:startCol" : "3",
@@ -614,7 +614,7 @@
 "p56" : {
 "rdt:name" : "h(x)",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.42",
+"rdt:elapsedTime" : "0.452",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -625,7 +625,7 @@
 "p57" : {
 "rdt:name" : "x  <-  x",
 "rdt:type" : "Binding",
-"rdt:elapsedTime" : "0.42",
+"rdt:elapsedTime" : "0.453",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -636,7 +636,7 @@
 "p58" : {
 "rdt:name" : "h",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.45",
+"rdt:elapsedTime" : "0.485",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -647,18 +647,18 @@
 "p59" : {
 "rdt:name" : "return(1)",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.45",
-"rdt:scriptNum" : "-1",
-"rdt:startLine" : "-1",
-"rdt:startCol" : "-1",
-"rdt:endLine" : "-1",
-"rdt:endCol" : "-1"
+"rdt:elapsedTime" : "0.492",
+"rdt:scriptNum" : "3",
+"rdt:startLine" : "12",
+"rdt:startCol" : "3",
+"rdt:endLine" : "12",
+"rdt:endCol" : "11"
 } ,
 
 "p60" : {
 "rdt:name" : "h(x)",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.47",
+"rdt:elapsedTime" : "0.496",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -669,7 +669,7 @@
 "p61" : {
 "rdt:name" : "h(x)",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.47",
+"rdt:elapsedTime" : "0.497",
 "rdt:scriptNum" : "3",
 "rdt:startLine" : "3",
 "rdt:startCol" : "3",
@@ -680,7 +680,7 @@
 "p62" : {
 "rdt:name" : "return(1)",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.47",
+"rdt:elapsedTime" : "0.509",
 "rdt:scriptNum" : "3",
 "rdt:startLine" : "4",
 "rdt:startCol" : "3",
@@ -691,7 +691,7 @@
 "p63" : {
 "rdt:name" : "f(x)",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.49",
+"rdt:elapsedTime" : "0.514",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -702,7 +702,7 @@
 "p64" : {
 "rdt:name" : "f(x)",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.49",
+"rdt:elapsedTime" : "0.516",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -713,7 +713,7 @@
 "p65" : {
 "rdt:name" : "x  <-  x",
 "rdt:type" : "Binding",
-"rdt:elapsedTime" : "0.49",
+"rdt:elapsedTime" : "0.517",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -724,7 +724,7 @@
 "p66" : {
 "rdt:name" : "f",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.49",
+"rdt:elapsedTime" : "0.523",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -735,7 +735,7 @@
 "p67" : {
 "rdt:name" : "g(x)",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.5",
+"rdt:elapsedTime" : "0.529",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -746,7 +746,7 @@
 "p68" : {
 "rdt:name" : "x  <-  x",
 "rdt:type" : "Binding",
-"rdt:elapsedTime" : "0.5",
+"rdt:elapsedTime" : "0.53",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -757,7 +757,7 @@
 "p69" : {
 "rdt:name" : "g",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.5",
+"rdt:elapsedTime" : "0.535",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -768,18 +768,18 @@
 "p70" : {
 "rdt:name" : "return(1)",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.5",
-"rdt:scriptNum" : "-1",
-"rdt:startLine" : "-1",
-"rdt:startCol" : "-1",
-"rdt:endLine" : "-1",
-"rdt:endCol" : "-1"
+"rdt:elapsedTime" : "0.543",
+"rdt:scriptNum" : "3",
+"rdt:startLine" : "8",
+"rdt:startCol" : "3",
+"rdt:endLine" : "8",
+"rdt:endCol" : "11"
 } ,
 
 "p71" : {
 "rdt:name" : "g(x)",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.52",
+"rdt:elapsedTime" : "0.547",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -790,7 +790,7 @@
 "p72" : {
 "rdt:name" : "g(x)",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.52",
+"rdt:elapsedTime" : "0.547",
 "rdt:scriptNum" : "3",
 "rdt:startLine" : "2",
 "rdt:startCol" : "3",
@@ -801,7 +801,7 @@
 "p73" : {
 "rdt:name" : "h(x)",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.52",
+"rdt:elapsedTime" : "0.556",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -812,7 +812,7 @@
 "p74" : {
 "rdt:name" : "x  <-  x",
 "rdt:type" : "Binding",
-"rdt:elapsedTime" : "0.52",
+"rdt:elapsedTime" : "0.557",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -823,7 +823,7 @@
 "p75" : {
 "rdt:name" : "h",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.53",
+"rdt:elapsedTime" : "0.563",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -834,18 +834,18 @@
 "p76" : {
 "rdt:name" : "return(1)",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.53",
-"rdt:scriptNum" : "-1",
-"rdt:startLine" : "-1",
-"rdt:startCol" : "-1",
-"rdt:endLine" : "-1",
-"rdt:endCol" : "-1"
+"rdt:elapsedTime" : "0.57",
+"rdt:scriptNum" : "3",
+"rdt:startLine" : "12",
+"rdt:startCol" : "3",
+"rdt:endLine" : "12",
+"rdt:endCol" : "11"
 } ,
 
 "p77" : {
 "rdt:name" : "h(x)",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.53",
+"rdt:elapsedTime" : "0.574",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -856,7 +856,7 @@
 "p78" : {
 "rdt:name" : "h(x)",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.53",
+"rdt:elapsedTime" : "0.575",
 "rdt:scriptNum" : "3",
 "rdt:startLine" : "3",
 "rdt:startCol" : "3",
@@ -867,7 +867,7 @@
 "p79" : {
 "rdt:name" : "return(1)",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.55",
+"rdt:elapsedTime" : "0.585",
 "rdt:scriptNum" : "3",
 "rdt:startLine" : "4",
 "rdt:startCol" : "3",
@@ -878,7 +878,7 @@
 "p80" : {
 "rdt:name" : "f(x)",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.55",
+"rdt:elapsedTime" : "0.588",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -889,7 +889,7 @@
 "p81" : {
 "rdt:name" : "source3.r",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.55",
+"rdt:elapsedTime" : "0.589",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -900,7 +900,7 @@
 "p82" : {
 "rdt:name" : "source(\"source3.r\")",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.55",
+"rdt:elapsedTime" : "0.59",
 "rdt:scriptNum" : "0",
 "rdt:startLine" : "21",
 "rdt:startCol" : "1",
@@ -911,7 +911,7 @@
 "p83" : {
 "rdt:name" : "source4.r",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.58",
+"rdt:elapsedTime" : "0.619",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -922,7 +922,7 @@
 "p84" : {
 "rdt:name" : "x <- 5",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.58",
+"rdt:elapsedTime" : "0.62",
 "rdt:scriptNum" : "4",
 "rdt:startLine" : "3",
 "rdt:startCol" : "1",
@@ -931,42 +931,42 @@
 } ,
 
 "p85" : {
-"rdt:name" : "f <- function(w) {    ddg.function()    ddg.return.value(w +",
+"rdt:name" : "f <- function(w) {    return(w + 1)}",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.58",
+"rdt:elapsedTime" : "0.624",
 "rdt:scriptNum" : "4",
 "rdt:startLine" : "4",
 "rdt:startCol" : "1",
-"rdt:endLine" : "7",
+"rdt:endLine" : "6",
 "rdt:endCol" : "1"
 } ,
 
 "p86" : {
 "rdt:name" : "y <- 4",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.59",
+"rdt:elapsedTime" : "0.629",
 "rdt:scriptNum" : "4",
-"rdt:startLine" : "10",
+"rdt:startLine" : "9",
 "rdt:startCol" : "1",
-"rdt:endLine" : "10",
+"rdt:endLine" : "9",
 "rdt:endCol" : "6"
 } ,
 
 "p87" : {
 "rdt:name" : "z <- f(x) + y",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.59",
+"rdt:elapsedTime" : "0.633",
 "rdt:scriptNum" : "4",
-"rdt:startLine" : "11",
+"rdt:startLine" : "10",
 "rdt:startCol" : "1",
-"rdt:endLine" : "11",
+"rdt:endLine" : "10",
 "rdt:endCol" : "13"
 } ,
 
 "p88" : {
 "rdt:name" : "f(x)",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.59",
+"rdt:elapsedTime" : "0.64",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -977,7 +977,7 @@
 "p89" : {
 "rdt:name" : "w  <-  x",
 "rdt:type" : "Binding",
-"rdt:elapsedTime" : "0.59",
+"rdt:elapsedTime" : "0.641",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -988,7 +988,7 @@
 "p90" : {
 "rdt:name" : "f",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.61",
+"rdt:elapsedTime" : "0.646",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -999,18 +999,18 @@
 "p91" : {
 "rdt:name" : "return(w + 1)",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.61",
-"rdt:scriptNum" : "-1",
-"rdt:startLine" : "-1",
-"rdt:startCol" : "-1",
-"rdt:endLine" : "-1",
-"rdt:endCol" : "-1"
+"rdt:elapsedTime" : "0.651",
+"rdt:scriptNum" : "4",
+"rdt:startLine" : "NA",
+"rdt:startCol" : "NA",
+"rdt:endLine" : "NA",
+"rdt:endCol" : "NA"
 } ,
 
 "p92" : {
 "rdt:name" : "f(x)",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.61",
+"rdt:elapsedTime" : "0.658",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -1021,29 +1021,29 @@
 "p93" : {
 "rdt:name" : "z <- f(x) + y",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.63",
+"rdt:elapsedTime" : "0.658",
 "rdt:scriptNum" : "4",
-"rdt:startLine" : "11",
+"rdt:startLine" : "10",
 "rdt:startCol" : "1",
-"rdt:endLine" : "11",
+"rdt:endLine" : "10",
 "rdt:endCol" : "13"
 } ,
 
 "p94" : {
 "rdt:name" : "w <- f(x)",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.63",
+"rdt:elapsedTime" : "0.662",
 "rdt:scriptNum" : "4",
-"rdt:startLine" : "14",
+"rdt:startLine" : "13",
 "rdt:startCol" : "1",
-"rdt:endLine" : "14",
+"rdt:endLine" : "13",
 "rdt:endCol" : "9"
 } ,
 
 "p95" : {
 "rdt:name" : "f(x)",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.63",
+"rdt:elapsedTime" : "0.668",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -1054,7 +1054,7 @@
 "p96" : {
 "rdt:name" : "w  <-  x",
 "rdt:type" : "Binding",
-"rdt:elapsedTime" : "0.63",
+"rdt:elapsedTime" : "0.669",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -1065,7 +1065,7 @@
 "p97" : {
 "rdt:name" : "f",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.63",
+"rdt:elapsedTime" : "0.673",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -1076,18 +1076,18 @@
 "p98" : {
 "rdt:name" : "return(w + 1)",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.64",
-"rdt:scriptNum" : "-1",
-"rdt:startLine" : "-1",
-"rdt:startCol" : "-1",
-"rdt:endLine" : "-1",
-"rdt:endCol" : "-1"
+"rdt:elapsedTime" : "0.678",
+"rdt:scriptNum" : "4",
+"rdt:startLine" : "NA",
+"rdt:startCol" : "NA",
+"rdt:endLine" : "NA",
+"rdt:endCol" : "NA"
 } ,
 
 "p99" : {
 "rdt:name" : "f(x)",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.64",
+"rdt:elapsedTime" : "0.683",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -1098,18 +1098,18 @@
 "p100" : {
 "rdt:name" : "w <- f(x)",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.64",
+"rdt:elapsedTime" : "0.684",
 "rdt:scriptNum" : "4",
-"rdt:startLine" : "14",
+"rdt:startLine" : "13",
 "rdt:startCol" : "1",
-"rdt:endLine" : "14",
+"rdt:endLine" : "13",
 "rdt:endCol" : "9"
 } ,
 
 "p101" : {
 "rdt:name" : "source4.r",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.64",
+"rdt:elapsedTime" : "0.688",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -1120,7 +1120,7 @@
 "p102" : {
 "rdt:name" : "source(\"source4.r\", local = T)",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.64",
+"rdt:elapsedTime" : "0.69",
 "rdt:scriptNum" : "0",
 "rdt:startLine" : "24",
 "rdt:startCol" : "1",
@@ -1131,7 +1131,7 @@
 "p103" : {
 "rdt:name" : "Stuff",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.66",
+"rdt:elapsedTime" : "0.735",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -1142,7 +1142,7 @@
 "p104" : {
 "rdt:name" : "m <- 10",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.66",
+"rdt:elapsedTime" : "0.737",
 "rdt:scriptNum" : "0",
 "rdt:startLine" : "32",
 "rdt:startCol" : "1",
@@ -1153,7 +1153,7 @@
 "p105" : {
 "rdt:name" : "f(m)",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.69",
+"rdt:elapsedTime" : "0.743",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -1164,7 +1164,7 @@
 "p106" : {
 "rdt:name" : "w  <-  m",
 "rdt:type" : "Binding",
-"rdt:elapsedTime" : "0.69",
+"rdt:elapsedTime" : "0.744",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -1175,7 +1175,7 @@
 "p107" : {
 "rdt:name" : "f",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.7",
+"rdt:elapsedTime" : "0.752",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -1186,18 +1186,18 @@
 "p108" : {
 "rdt:name" : "return(w + 1)",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.72",
-"rdt:scriptNum" : "-1",
-"rdt:startLine" : "-1",
-"rdt:startCol" : "-1",
-"rdt:endLine" : "-1",
-"rdt:endCol" : "-1"
+"rdt:elapsedTime" : "0.763",
+"rdt:scriptNum" : "4",
+"rdt:startLine" : "NA",
+"rdt:startCol" : "NA",
+"rdt:endLine" : "NA",
+"rdt:endCol" : "NA"
 } ,
 
 "p109" : {
 "rdt:name" : "f(m)",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.72",
+"rdt:elapsedTime" : "0.771",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -1208,7 +1208,7 @@
 "p110" : {
 "rdt:name" : "f(x)",
 "rdt:type" : "Start",
-"rdt:elapsedTime" : "0.72",
+"rdt:elapsedTime" : "0.773",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -1219,7 +1219,7 @@
 "p111" : {
 "rdt:name" : "w  <-  x",
 "rdt:type" : "Binding",
-"rdt:elapsedTime" : "0.72",
+"rdt:elapsedTime" : "0.774",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -1230,7 +1230,7 @@
 "p112" : {
 "rdt:name" : "f",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.74",
+"rdt:elapsedTime" : "0.781",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -1241,18 +1241,18 @@
 "p113" : {
 "rdt:name" : "return(w + 1)",
 "rdt:type" : "Operation",
-"rdt:elapsedTime" : "0.75",
-"rdt:scriptNum" : "-1",
-"rdt:startLine" : "-1",
-"rdt:startCol" : "-1",
-"rdt:endLine" : "-1",
-"rdt:endCol" : "-1"
+"rdt:elapsedTime" : "0.792",
+"rdt:scriptNum" : "4",
+"rdt:startLine" : "NA",
+"rdt:startCol" : "NA",
+"rdt:endLine" : "NA",
+"rdt:endCol" : "NA"
 } ,
 
 "p114" : {
 "rdt:name" : "f(x)",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.75",
+"rdt:elapsedTime" : "0.8",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -1263,7 +1263,7 @@
 "p115" : {
 "rdt:name" : "Stuff",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.75",
+"rdt:elapsedTime" : "0.802",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -1274,7 +1274,7 @@
 "p116" : {
 "rdt:name" : "SourceFuncTest.R",
 "rdt:type" : "Finish",
-"rdt:elapsedTime" : "0.75",
+"rdt:elapsedTime" : "0.803",
 "rdt:scriptNum" : "NA",
 "rdt:startLine" : "NA",
 "rdt:startCol" : "NA",
@@ -1285,30 +1285,37 @@
 "environment" : {
 "rdt:name" : "environment",
 "rdt:architecture" : "x86_64",
-"rdt:operatingSystem" : "windows",
+"rdt:operatingSystem" : "unix",
 "rdt:language" : "R",
-"rdt:rVersion" : "R version 3.3.1 (2016-06-21)",
+"rdt:rVersion" : "R version 3.3.3 (2017-03-06)",
 "rdt:script" : "[DIR]/SourceFuncTest.R",
 "rdt:sourcedScripts" : [
 	{"number" : "1",
                              "name" : "source1.r",
-                             "timestamp" : "2017-01-06T19.13.45EST"},
+                             "timestamp" : "2017-01-06T17.10.23EST"},
 	{"number" : "2",
                              "name" : "source2.r",
-                             "timestamp" : "2017-01-06T19.13.45EST"},
+                             "timestamp" : "2017-01-06T17.10.23EST"},
 	{"number" : "3",
                              "name" : "source3.r",
-                             "timestamp" : "2017-01-06T19.13.45EST"},
+                             "timestamp" : "2017-06-27T14.57.45EDT"},
 	{"number" : "4",
                              "name" : "source4.r",
-                             "timestamp" : "2017-01-06T19.13.45EST"} ],
-"rdt:scriptTimeStamp" : "2017-01-06T19.13.45EST",
+                             "timestamp" : "2017-06-27T14.57.56EDT"} ],
+"rdt:scriptTimeStamp" : "2017-01-06T17.10.23EST",
 "rdt:workingDirectory" : "[DIR]",
 "rdt:ddgDirectory" : "[DIR]/ddg",
-"rdt:ddgTimeStamp" : "2017-05-24T21.28.39EDT",
-"rdt:rdatatrackerVersion" : "2.26.1",
+"rdt:ddgTimeStamp" : "2017-06-27T15.08.50EDT",
+"rdt:rdatatrackerVersion" : "2.26.2",
 "rdt:installedPackages" : [
-	{"package" : "RDataTracker", "version" : "2.26.1"}]
+	{"package" : "base", "version" : "3.3.3"},
+	{"package" : "datasets", "version" : "3.3.3"},
+	{"package" : "graphics", "version" : "3.3.3"},
+	{"package" : "grDevices", "version" : "3.3.3"},
+	{"package" : "methods", "version" : "3.3.3"},
+	{"package" : "RDataTracker", "version" : "2.26.2"},
+	{"package" : "stats", "version" : "3.3.3"},
+	{"package" : "utils", "version" : "3.3.3"}]
 }},
 "entity":{
 
@@ -1350,7 +1357,7 @@
 "rdt:value" : "6",
 "rdt:valType" : {"container":"vector", "dimension":[1], "type":["numeric"]},
 "rdt:type" : "Data",
-"rdt:scope" : "0x0000000013b33648",
+"rdt:scope" : "0x7facdef3e0a8",
 "rdt:fromEnv" : "FALSE",
 "rdt:timestamp" : "",
 "rdt:location" : ""
@@ -1361,7 +1368,7 @@
 "rdt:value" : "10",
 "rdt:valType" : {"container":"vector", "dimension":[1], "type":["numeric"]},
 "rdt:type" : "Data",
-"rdt:scope" : "0x0000000013b33648",
+"rdt:scope" : "0x7facdef3e0a8",
 "rdt:fromEnv" : "FALSE",
 "rdt:timestamp" : "",
 "rdt:location" : ""
@@ -1405,7 +1412,7 @@
 "rdt:value" : "22",
 "rdt:valType" : {"container":"vector", "dimension":[1], "type":["numeric"]},
 "rdt:type" : "Data",
-"rdt:scope" : "0x0000000013dc9948",
+"rdt:scope" : "0x7facde7be498",
 "rdt:fromEnv" : "FALSE",
 "rdt:timestamp" : "",
 "rdt:location" : ""
@@ -1416,7 +1423,7 @@
 "rdt:value" : "10",
 "rdt:valType" : {"container":"vector", "dimension":[1], "type":["numeric"]},
 "rdt:type" : "Data",
-"rdt:scope" : "0x0000000013dc9948",
+"rdt:scope" : "0x7facde7be498",
 "rdt:fromEnv" : "FALSE",
 "rdt:timestamp" : "",
 "rdt:location" : ""
@@ -1471,7 +1478,7 @@
 "rdt:value" : "32",
 "rdt:valType" : {"container":"vector", "dimension":[1], "type":["numeric"]},
 "rdt:type" : "Data",
-"rdt:scope" : "0x0000000013165f28",
+"rdt:scope" : "0x7face25b8b10",
 "rdt:fromEnv" : "FALSE",
 "rdt:timestamp" : "",
 "rdt:location" : ""
@@ -1482,7 +1489,7 @@
 "rdt:value" : "0",
 "rdt:valType" : {"container":"vector", "dimension":[1], "type":["numeric"]},
 "rdt:type" : "Data",
-"rdt:scope" : "0x0000000013165f28",
+"rdt:scope" : "0x7face25b8b10",
 "rdt:fromEnv" : "FALSE",
 "rdt:timestamp" : "",
 "rdt:location" : ""
@@ -1625,7 +1632,7 @@
 "rdt:value" : "10",
 "rdt:valType" : {"container":"vector", "dimension":[1], "type":["numeric"]},
 "rdt:type" : "Data",
-"rdt:scope" : "0x000000001606f758",
+"rdt:scope" : "0x7face30a7f08",
 "rdt:fromEnv" : "FALSE",
 "rdt:timestamp" : "",
 "rdt:location" : ""
@@ -1636,7 +1643,7 @@
 "rdt:value" : "10",
 "rdt:valType" : {"container":"vector", "dimension":[1], "type":["numeric"]},
 "rdt:type" : "Data",
-"rdt:scope" : "0x0000000015f1ed68",
+"rdt:scope" : "0x7face276ee40",
 "rdt:fromEnv" : "FALSE",
 "rdt:timestamp" : "",
 "rdt:location" : ""
@@ -1658,7 +1665,7 @@
 "rdt:value" : "10",
 "rdt:valType" : {"container":"vector", "dimension":[1], "type":["numeric"]},
 "rdt:type" : "Data",
-"rdt:scope" : "0x0000000015d9a958",
+"rdt:scope" : "0x7face24ff070",
 "rdt:fromEnv" : "FALSE",
 "rdt:timestamp" : "",
 "rdt:location" : ""
@@ -1691,7 +1698,7 @@
 "rdt:value" : "10",
 "rdt:valType" : {"container":"vector", "dimension":[1], "type":["numeric"]},
 "rdt:type" : "Data",
-"rdt:scope" : "0x000000001600ac18",
+"rdt:scope" : "0x7face42e6ed0",
 "rdt:fromEnv" : "FALSE",
 "rdt:timestamp" : "",
 "rdt:location" : ""
@@ -1702,7 +1709,7 @@
 "rdt:value" : "10",
 "rdt:valType" : {"container":"vector", "dimension":[1], "type":["numeric"]},
 "rdt:type" : "Data",
-"rdt:scope" : "0x0000000016bc6b48",
+"rdt:scope" : "0x7face28472e0",
 "rdt:fromEnv" : "FALSE",
 "rdt:timestamp" : "",
 "rdt:location" : ""
@@ -1724,7 +1731,7 @@
 "rdt:value" : "10",
 "rdt:valType" : {"container":"vector", "dimension":[1], "type":["numeric"]},
 "rdt:type" : "Data",
-"rdt:scope" : "0x0000000013f7b588",
+"rdt:scope" : "0x7face2d21e28",
 "rdt:fromEnv" : "FALSE",
 "rdt:timestamp" : "",
 "rdt:location" : ""
@@ -1801,7 +1808,7 @@
 "rdt:value" : "5",
 "rdt:valType" : {"container":"vector", "dimension":[1], "type":["numeric"]},
 "rdt:type" : "Data",
-"rdt:scope" : "0x0000000013e0e7f8",
+"rdt:scope" : "0x7face231a878",
 "rdt:fromEnv" : "FALSE",
 "rdt:timestamp" : "",
 "rdt:location" : ""
@@ -1834,7 +1841,7 @@
 "rdt:value" : "5",
 "rdt:valType" : {"container":"vector", "dimension":[1], "type":["numeric"]},
 "rdt:type" : "Data",
-"rdt:scope" : "0x0000000015ca6da0",
+"rdt:scope" : "0x7face42f24d8",
 "rdt:fromEnv" : "FALSE",
 "rdt:timestamp" : "",
 "rdt:location" : ""
@@ -1889,7 +1896,7 @@
 "rdt:value" : "10",
 "rdt:valType" : {"container":"vector", "dimension":[1], "type":["numeric"]},
 "rdt:type" : "Data",
-"rdt:scope" : "0x0000000016728120",
+"rdt:scope" : "0x7face277e640",
 "rdt:fromEnv" : "FALSE",
 "rdt:timestamp" : "",
 "rdt:location" : ""
@@ -1911,7 +1918,7 @@
 "rdt:value" : "5",
 "rdt:valType" : {"container":"vector", "dimension":[1], "type":["numeric"]},
 "rdt:type" : "Data",
-"rdt:scope" : "0x00000000164b10d8",
+"rdt:scope" : "0x7face27bd7c8",
 "rdt:fromEnv" : "FALSE",
 "rdt:timestamp" : "",
 "rdt:location" : ""
@@ -2389,117 +2396,117 @@
 "prov:informed" : "p93"
 } ,
 
-"e217" : {
+"e215" : {
 "prov:informant" : "p93",
 "prov:informed" : "p94"
 } ,
 
-"e220" : {
+"e218" : {
 "prov:informant" : "p94",
 "prov:informed" : "p95"
 } ,
 
-"e221" : {
+"e219" : {
 "prov:informant" : "p95",
 "prov:informed" : "p96"
 } ,
 
-"e226" : {
+"e224" : {
 "prov:informant" : "p96",
 "prov:informed" : "p97"
 } ,
 
-"e227" : {
+"e225" : {
 "prov:informant" : "p97",
 "prov:informed" : "p98"
 } ,
 
-"e230" : {
+"e228" : {
 "prov:informant" : "p98",
 "prov:informed" : "p99"
 } ,
 
-"e231" : {
+"e229" : {
 "prov:informant" : "p99",
 "prov:informed" : "p100"
 } ,
 
-"e236" : {
+"e232" : {
 "prov:informant" : "p100",
 "prov:informed" : "p101"
 } ,
 
-"e237" : {
+"e233" : {
 "prov:informant" : "p101",
 "prov:informed" : "p102"
 } ,
 
-"e239" : {
+"e235" : {
 "prov:informant" : "p102",
 "prov:informed" : "p103"
 } ,
 
-"e240" : {
+"e236" : {
 "prov:informant" : "p103",
 "prov:informed" : "p104"
 } ,
 
-"e242" : {
+"e238" : {
 "prov:informant" : "p104",
 "prov:informed" : "p105"
 } ,
 
-"e243" : {
+"e239" : {
 "prov:informant" : "p105",
 "prov:informed" : "p106"
 } ,
 
-"e248" : {
+"e244" : {
 "prov:informant" : "p106",
 "prov:informed" : "p107"
 } ,
 
-"e249" : {
+"e245" : {
 "prov:informant" : "p107",
 "prov:informed" : "p108"
 } ,
 
-"e252" : {
+"e248" : {
 "prov:informant" : "p108",
 "prov:informed" : "p109"
 } ,
 
-"e253" : {
+"e249" : {
 "prov:informant" : "p109",
 "prov:informed" : "p110"
 } ,
 
-"e254" : {
+"e250" : {
 "prov:informant" : "p110",
 "prov:informed" : "p111"
 } ,
 
-"e259" : {
+"e255" : {
 "prov:informant" : "p111",
 "prov:informed" : "p112"
 } ,
 
-"e260" : {
+"e256" : {
 "prov:informant" : "p112",
 "prov:informed" : "p113"
 } ,
 
-"e263" : {
+"e259" : {
 "prov:informant" : "p113",
 "prov:informed" : "p114"
 } ,
 
-"e264" : {
+"e260" : {
 "prov:informant" : "p114",
 "prov:informed" : "p115"
 } ,
 
-"e265" : {
+"e261" : {
 "prov:informant" : "p115",
 "prov:informed" : "p116"
 }},
@@ -2720,47 +2727,47 @@
 "prov:activity" : "p91"
 } ,
 
-"e216" : {
+"e214" : {
 "prov:entity" : "d47",
 "prov:activity" : "p93"
 } ,
 
-"e223" : {
+"e221" : {
 "prov:entity" : "d48",
 "prov:activity" : "p96"
 } ,
 
-"e228" : {
+"e226" : {
 "prov:entity" : "d49",
 "prov:activity" : "p98"
 } ,
 
-"e235" : {
+"e231" : {
 "prov:entity" : "d50",
 "prov:activity" : "p100"
 } ,
 
-"e241" : {
+"e237" : {
 "prov:entity" : "d52",
 "prov:activity" : "p104"
 } ,
 
-"e245" : {
+"e241" : {
 "prov:entity" : "d53",
 "prov:activity" : "p106"
 } ,
 
-"e250" : {
+"e246" : {
 "prov:entity" : "d54",
 "prov:activity" : "p108"
 } ,
 
-"e256" : {
+"e252" : {
 "prov:entity" : "d55",
 "prov:activity" : "p111"
 } ,
 
-"e261" : {
+"e257" : {
 "prov:entity" : "d56",
 "prov:activity" : "p113"
 }},
@@ -3153,105 +3160,85 @@
 
 "e213" : {
 "prov:activity" : "p93",
-"prov:entity" : "d34"
-} ,
-
-"e214" : {
-"prov:activity" : "p93",
-"prov:entity" : "d40"
-} ,
-
-"e215" : {
-"prov:activity" : "p93",
 "prov:entity" : "d46"
 } ,
 
-"e218" : {
+"e216" : {
 "prov:activity" : "p94",
 "prov:entity" : "d43"
 } ,
 
-"e219" : {
+"e217" : {
 "prov:activity" : "p94",
 "prov:entity" : "d42"
 } ,
 
-"e222" : {
+"e220" : {
 "prov:activity" : "p96",
 "prov:entity" : "d42"
 } ,
 
-"e224" : {
+"e222" : {
 "prov:activity" : "p97",
 "prov:entity" : "d43"
 } ,
 
-"e225" : {
+"e223" : {
 "prov:activity" : "p97",
 "prov:entity" : "d48"
 } ,
 
-"e229" : {
+"e227" : {
 "prov:activity" : "p98",
 "prov:entity" : "d48"
 } ,
 
-"e232" : {
-"prov:activity" : "p100",
-"prov:entity" : "d34"
-} ,
-
-"e233" : {
-"prov:activity" : "p100",
-"prov:entity" : "d40"
-} ,
-
-"e234" : {
+"e230" : {
 "prov:activity" : "p100",
 "prov:entity" : "d49"
 } ,
 
-"e238" : {
+"e234" : {
 "prov:activity" : "p102",
 "prov:entity" : "d51"
 } ,
 
-"e244" : {
+"e240" : {
 "prov:activity" : "p106",
 "prov:entity" : "d52"
 } ,
 
-"e246" : {
+"e242" : {
 "prov:activity" : "p107",
 "prov:entity" : "d43"
 } ,
 
-"e247" : {
+"e243" : {
 "prov:activity" : "p107",
 "prov:entity" : "d53"
 } ,
 
-"e251" : {
+"e247" : {
 "prov:activity" : "p108",
 "prov:entity" : "d53"
 } ,
 
-"e255" : {
+"e251" : {
 "prov:activity" : "p111",
 "prov:entity" : "d42"
 } ,
 
-"e257" : {
+"e253" : {
 "prov:activity" : "p112",
 "prov:entity" : "d43"
 } ,
 
-"e258" : {
+"e254" : {
 "prov:activity" : "p112",
 "prov:entity" : "d55"
 } ,
 
-"e262" : {
+"e258" : {
 "prov:activity" : "p113",
 "prov:entity" : "d55"
 }}

--- a/tests/SourceFuncTest/source3.r
+++ b/tests/SourceFuncTest/source3.r
@@ -5,14 +5,10 @@ f <- function(x) {
 }
 
 g <- function(x) {
-#  ddg.function()
-#  return(ddg.return.value(1))
   return(1)
 }
 
 h <- function(x) {
-#  ddg.function()
-#  return(ddg.return.value(1))
   return(1)
 }
 

--- a/tests/SourceFuncTest/source3.r
+++ b/tests/SourceFuncTest/source3.r
@@ -5,13 +5,15 @@ f <- function(x) {
 }
 
 g <- function(x) {
-  ddg.function()
-  return(ddg.return.value(1))
+#  ddg.function()
+#  return(ddg.return.value(1))
+  return(1)
 }
 
 h <- function(x) {
-  ddg.function()
-  return(ddg.return.value(1))
+#  ddg.function()
+#  return(ddg.return.value(1))
+  return(1)
 }
 
 someVector <- function() {

--- a/tests/SourceFuncTest/source4.r
+++ b/tests/SourceFuncTest/source4.r
@@ -2,8 +2,6 @@
 # execute locally using ddg.source. It also uses ddg.return and ddg.procedure.
 x <- 5
 f <- function(w){
-#  ddg.function()
-#  ddg.return.value(w+1)
   return(w+1)
 }
 

--- a/tests/SourceFuncTest/source4.r
+++ b/tests/SourceFuncTest/source4.r
@@ -2,8 +2,9 @@
 # execute locally using ddg.source. It also uses ddg.return and ddg.procedure.
 x <- 5
 f <- function(w){
-  ddg.function()
-  ddg.return.value(w+1)
+#  ddg.function()
+#  ddg.return.value(w+1)
+  return(w+1)
 }
 
 # just random testing


### PR DESCRIPTION
ddg.annotate.on and off were not working since the introduction of the DDGStatement class.  That is now fixed.  In addition, they can now be used to turn annotation of individual functions on and off dynamically.
