### PR TITLE
Automatic prov-json compliance checking in regression tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ r_packages:
   - gridExtra
   - gWidgets
   - jsonlite
+  - jsonvalidate
   - mgcv
   - mosaic
   - plyr

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
       r-cran-reshape2
       r-cran-rcurl
       r-cran-plyr
+      r-cran-v8
 
 r_packages:
   - akima
@@ -52,8 +53,6 @@ r_packages:
   - xkcd
   - zoo
   - jsonvalidate
-  - libv8-3.14-dev
-  - grid
 
 before_script:
   - "export DISPLAY=:99.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ r_packages:
   - xkcd
   - zoo
   - jsonvalidate
-  - V8
+  - libv8-3.14-dev
   - grid
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ r_packages:
   - gridExtra
   - gWidgets
   - jsonlite
+  - jsonvalidate
   - mgcv
   - mosaic
   - plyr
@@ -52,7 +53,6 @@ r_packages:
   - sysfonts
   - xkcd
   - zoo
-  - jsonvalidate
 
 before_script:
   - "export DISPLAY=:99.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ r_packages:
   - gridExtra
   - gWidgets
   - jsonlite
-  - jsonvalidate
   - mgcv
   - mosaic
   - plyr
@@ -52,6 +51,9 @@ r_packages:
   - sysfonts
   - xkcd
   - zoo
+  - jsonvalidate
+  - V8
+  - grid
 
 before_script:
   - "export DISPLAY=:99.0"

--- a/tests.xml
+++ b/tests.xml
@@ -202,14 +202,7 @@
     
     
     <!-- EF EDITs -->
-    <!--<exec executable="RScript" dir="tests/ProvJsonTest">
-      <arg value="ProvJsonTest.r" />
-      <arg path="tests/ProvJsonTest/schema.json" />
-      <arg path="${local_dir}/ddg.json.local" />
-    </exec>
-    -->
-    
-    <!--<antcall target= -->
+    <antcall target="prov-json-compliance-test" />
     
 
     <!-- Delete all local environment information (except sourced scripts & installed packages) -->
@@ -1053,20 +1046,21 @@
   
   
   <!-- EF EDITS -->
-  <target name="testing">
-    <exec executable="RScript" dir="tests/ProvJsonTest">
+  <target name="prov-json-compliance-test">
+    <exec executable="RScript" dir="tests/ProvJsonTest" resultproperty="compliant">
       <arg value="ProvJsonTest.r" />
       <arg path="tests/ProvJsonTest/schema.json" />
       <arg path="${local_dir}/ddg.json.local" />
     </exec>
+    <antcall target="prov-json-compliance-fail-check" />
   </target>
   
-  <target name="prov-json-compliance-test">
-    <exec executable="RScript" dir="tests/ProvJsonTest">
-      <arg value="ProvJsonTest.r" />
-      <arg path="tests/ProvJsonTest/schema.json" />
-      <arg path="${local_dir}/ddg.json.local" />
-    </exec>
+  <target name="prov-json-compliance-fail-check" if="using-travis">
+    <fail message="ddg.json is not prov-json compliant.">
+      <condition>
+        <equals arg1="${compliant}" arg2="1"/>
+      </condition>
+    </fail>
   </target>
   
   

--- a/tests.xml
+++ b/tests.xml
@@ -1047,7 +1047,7 @@
   
   <!-- EF EDITS -->
   <target name="prov-json-compliance-test">
-    <exec executable="RScript" dir="tests/ProvJsonTest" resultproperty="compliant">
+    <exec executable="Rscript" dir="tests/ProvJsonTest" resultproperty="compliant">
       <arg value="ProvJsonTest.r" />
       <arg path="tests/ProvJsonTest/schema.json" />
       <arg path="${local_dir}/ddg.json.local" />

--- a/tests.xml
+++ b/tests.xml
@@ -199,6 +199,18 @@
       </fileset>
       <globmapper from="*" to="*.local"/>
     </copy>
+    
+    
+    <!-- EF EDITs -->
+    <!--<exec executable="RScript" dir="tests/ProvJsonTest">
+      <arg value="ProvJsonTest.r" />
+      <arg path="tests/ProvJsonTest/schema.json" />
+      <arg path="${local_dir}/ddg.json.local" />
+    </exec>
+    -->
+    
+    <!--<antcall target= -->
+    
 
     <!-- Delete all local environment information (except sourced scripts & installed packages) -->
     <replaceregexp flags="g">
@@ -1038,5 +1050,24 @@
   </target>
 
   <!--################################# END UTILIES #################################-->
-
+  
+  
+  <!-- EF EDITS -->
+  <target name="testing">
+    <exec executable="RScript" dir="tests/ProvJsonTest">
+      <arg value="ProvJsonTest.r" />
+      <arg path="tests/ProvJsonTest/schema.json" />
+      <arg path="${local_dir}/ddg.json.local" />
+    </exec>
+  </target>
+  
+  <target name="prov-json-compliance-test">
+    <exec executable="RScript" dir="tests/ProvJsonTest">
+      <arg value="ProvJsonTest.r" />
+      <arg path="tests/ProvJsonTest/schema.json" />
+      <arg path="${local_dir}/ddg.json.local" />
+    </exec>
+  </target>
+  
+  
 </project>

--- a/tests.xml
+++ b/tests.xml
@@ -1,576 +1,612 @@
 <!--
-  This file supports testing of RDataTracker.  Each test case runs
-  RDataTracker and compares both its standard output and the created
-  ddg.json file to an expected result.  The comparison ignores differences
-  related to file paths, platform executed on and timestamps.  For each
-  test case, there is also a separate update task that can be used to
-  update the expected results.
+	This file supports testing of RDataTracker.  Each test case runs
+	RDataTracker and compares both its standard output and the created
+	ddg.json file to an expected result.  The comparison ignores differences
+	related to file paths, platform executed on and timestamps.  For each
+	test case, there is also a separate update task that can be used to
+	update the expected results.
 
-  To run it, use:
+	To run it, use:
 
-  > ant -file tests.xml
+	> ant -file tests.xml
 
-  Start with basicTest
+	Start with basicTest
 
-  > ant -file tests.xml basicTest
+	> ant -file tests.xml basicTest
 
-  When you run a test, it will create several files with names like:
+	When you run a test, it will create several files with names like:
 
-  <target>.out - standard output from executing the test
-  ddg/ddg.json - ddg from executing the test
+	<target>.out - standard output from executing the test
+	ddg/ddg.json - ddg from executing the test
 
-  After a test is run, the .out files and the ddg.json files are compared
-  to expected_ files with the same names.  The differences are displayed
-  on standard output.  If the tests work as before, the only differences
-  you should see are in the execution time.
+	After a test is run, the .out files and the ddg.json files are compared
+	to expected_ files with the same names.  The differences are displayed
+	on standard output.  If the tests work as before, the only differences
+	you should see are in the execution time.
 
-  If the tests stop with Build failed, find the last test that was
-  attempted and look in its .out file(s).  Perhaps a library function has
-  changed and the test needs to be updated.  Perhaps the test needs a network
-  connection and you are not online.  It is usually easy to understand the
-  problem by looking at the .out files.
+	If the tests stop with Build failed, find the last test that was
+	attempted and look in its .out file(s).  Perhaps a library function has
+	changed and the test needs to be updated.  Perhaps the test needs a network
+	connection and you are not online.  It is usually easy to understand the
+	problem by looking at the .out files.
 
-  If the test results differ from the expected results as reported by the
-  diff output at the end of the test case run, examine the results.  If the
-  new version is incorrect, you should fix the problem and try again.  If
-  the new version is correct, then you have either fixed a bug or added
-  an enhancement and should update the expected results.  To do that, you
-  run an update task.  Update tasks are only provided for individual tests
-  to reduce the likelihood that somebody would inadvertently update all the
-  expected results.  The task is always named "update-<test>" where "<test>"
-  would be replaced with the name of the test, e.g. "update-basicTest".
+	If the test results differ from the expected results as reported by the
+	diff output at the end of the test case run, examine the results.  If the
+	new version is incorrect, you should fix the problem and try again.  If
+	the new version is correct, then you have either fixed a bug or added
+	an enhancement and should update the expected results.  To do that, you
+	run an update task.  Update tasks are only provided for individual tests
+	to reduce the likelihood that somebody would inadvertently update all the
+	expected results.  The task is always named "update-<test>" where "<test>"
+	would be replaced with the name of the test, e.g. "update-basicTest".
 
-  When basicTest works, move on to "normal-tests" which will run the following
-  test cases:
+	When basicTest works, move on to "normal-tests" which will run the following
+	test cases:
 
-  - basicTest
-  - S4ObjectTest
-  - ScopeTest
-  - ReturnTest
-  - OddParameterTest
-  - FunctionAnnotationTest
-  - AnnotateOnOffTest
-  - ControlConstructTest
-  - WarningTest
-  - PlotTest
-  - Plot2Test
-  - NoDevOffTest
-  - DataTypeTest
-  - HigherOrderFuncTest
-  - AssignmentOperatorsTest
-  - FunctionOriginTest
-  - DDGStatementTest
-  - RMarkdownTest
-  - ConnectionTest
+	- basicTest
+	- S4ObjectTest
+	- ScopeTest
+	- ReturnTest
+	- OddParameterTest
+	- FunctionAnnotationTest
+	- AnnotateOnOffTest
+	- ControlConstructTest
+	- WarningTest
+	- PlotTest
+	- Plot2Test
+	- NoDevOffTest
+	- DataTypeTest
+	- HigherOrderFuncTest
+	- AssignmentOperatorsTest
+	- FunctionOriginTest
+	- DDGStatementTest
+	- RMarkdownTest
+	- ConnectionTest
 
-  The target "source-tests" will run the following tests cases:
+	The target "source-tests" will run the following tests cases:
 
-  - SourceFuncTest
-  - OnOffTest <- temporarily removed
+	- SourceFuncTest
+	- OnOffTest <- temporarily removed
 
-  The target "bug-tests" will run the following test cases:
+	The target "bug-tests" will run the following test cases:
 
-  - ddgDeepNesting
+	- ddgDeepNesting
 
-  The target "script-tests" will run all the short-running real scripts:
+	The target "script-tests" will run all the short-running real scripts:
 
-  - CalculateSquareRoot
-  - DailySolarRadiation
-  - HFDatasetPreview
+	- CalculateSquareRoot
+	- DailySolarRadiation
+	- HFDatasetPreview
 
-  The target "test-all" will do all of the tests above.
+	The target "test-all" will do all of the tests above.
 
-  To add a new test case, duplicate one of the existing test and update tasks,
-  modify the name of the task and the value passed to run-regression-test
-  and update-regression-expected.  It is important that each test
-  script live in its own directory.  The value passed to run-regression-test
-  and update-regression-expected should be the directory name.  The
-  script inside that directory should have the same name, with .R appended to it.
-  When you add a new test case, you should also add it to one of the tasks that
-  group together test cases:
+	To add a new test case, duplicate one of the existing test and update tasks,
+	modify the name of the task and the value passed to run-regression-test
+	and update-regression-expected.  It is important that each test
+	script live in its own directory.  The value passed to run-regression-test
+	and update-regression-expected should be the directory name.  The
+	script inside that directory should have the same name, with .R appended to it.
+	When you add a new test case, you should also add it to one of the tasks that
+	group together test cases:
 
-  - normal-tests is used for basic R tests.
-  - script-tests is used for real R scripts that are short-running
-  - long-script-tests are used for real R scripts that are long-running
-  - bug-tests are tests that trigger a bug either in DDG Explorer or RDataTracker
+	- normal-tests is used for basic R tests.
+	- script-tests is used for real R scripts that are short-running
+	- long-script-tests are used for real R scripts that are long-running
+	- bug-tests are tests that trigger a bug either in DDG Explorer or RDataTracker
 
 -->
 
 <project
-    name="TESTS"
-    xmlns:if="ant:if"
-    xmlns:unless="ant:unless"
-    default="install-and-test"
-  >
+	name="TESTS"
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless"
+	default="install-and-test"
+	>
 
-  <!--############################# Start Setup #############################-->
+	<!--############################# Start Setup #############################-->
 
-  <!-- So we can build RDataTracker -->
-  <import file="build.xml" />
+	<!-- So we can build RDataTracker -->
+	<import file="build.xml" />
 
-  <!-- Get the base directory -->
-  <dirname
-      property="TESTS.basedir"
-      file="${ant.file.TESTS}"
-  />
+	<!-- Get the base directory -->
+	<dirname
+		property="TESTS.basedir"
+		file="${ant.file.TESTS}"
+	/>
 
-  <!-- For windows, we need to replace \ (backslashes) with / (forwardslashes) -->
-  <loadresource property="FILE.basedir">
-    <propertyresource name="TESTS.basedir"/>
-      <filterchain>
-        <tokenfilter>
-          <filetokenizer/>
-          <replacestring from="\" to="/"/>
-        </tokenfilter>
-      </filterchain>
-  </loadresource>
+	<!-- For windows, we need to replace \ (backslashes) with / (forwardslashes) -->
+	<loadresource property="FILE.basedir">
+		<propertyresource name="TESTS.basedir"/>
+		<filterchain>
+			<tokenfilter>
+				<filetokenizer/>
+				<replacestring from="\" to="/"/>
+			</tokenfilter>
+		</filterchain>
+	</loadresource>
 
-  <!--############################## End Setup ##############################-->
+	<!--############################## End Setup ##############################-->
 
 
-  <!--############################ Start FUNCTIONS ############################-->
+	<!--############################ Start FUNCTIONS ############################-->
 
-  <!-- Check for libraries needed by the tests -->
-  <target name="dependencies">
-    <exec executable="Rscript" dir="tests/" >
-      <arg line="depends.r" />
-    </exec>
-  </target>
+	<!-- Check for libraries needed by the tests -->
+	<target name="dependencies">
+		<exec executable="Rscript" dir="tests/" >
+			<arg line="depends.r" />
+		</exec>
+	</target>
 
-  <!-- Run a specified tests. Parameters needed are :
-    @param dir : specified the directory where the test files are contained. This
-                 directory should contain all files required by the test scripts
-                 as this is the working directory
-    @param out : specified the relative location and name of the output file where
-                 output from the script should be saved. If sourcing, a file is saved
-                 in the same location with the prefix "source_" added to the name.
-    @param script-file : the name of the script file to be executed, relative to dir
-    @param expected_out : the location and name of the expected output for this test.
-                          If sourcing, the expected source output is in the same location
-                          with the prefix "source_" attached
-    @param expected_ddg : the location and name of the expected ddg.json for this test.
-                          If sourcing, the expected source ddg.json is in the same directory
-                          with the prefix "source_" attached
-  -->
-  <target name="run-test">
-    <!-- Directory to store local files for comparison -->
-    <property name="local_dir" value="${dir}/local" />
-    <delete dir="${local_dir}" quiet="true" />
-    <mkdir dir="${local_dir}" />
+	<!-- Run a specified tests. Parameters needed are :
+		@param dir : specified the directory where the test files are contained. This
+					 directory should contain all files required by the test scripts
+					 as this is the working directory
+		@param out : specified the relative location and name of the output file where
+					 output from the script should be saved. If sourcing, a file is saved
+					 in the same location with the prefix "source_" added to the name.
+		@param script-file : the name of the script file to be executed, relative to dir
+		@param expected_out : the location and name of the expected output for this test.
+							  If sourcing, the expected source output is in the same location
+							  with the prefix "source_" attached
+		@param expected_ddg : the location and name of the expected ddg.json for this test.
+							  If sourcing, the expected source ddg.json is in the same directory
+							  with the prefix "source_" attached
+	-->
+	<target name="run-test">
+		<!-- Directory to store local files for comparison -->
+		<property name="local_dir" value="${dir}/local" />
+		<delete dir="${local_dir}" quiet="true" />
+		<mkdir dir="${local_dir}" />
 
-    <!-- Copy the source test file to this directory, and replace with correct script name and directory -->
-    <copy file="${FILE.basedir}/tests/sourceTest.r" todir="${dir}" overwrite="true"/>
-    <replaceregexp  file="${dir}/sourceTest.r"
-                    match="\[DIR_LOCAL\]"
-                    replace="${FILE.basedir}/${dir}"
-                    flags="g"
-    />
-    <replaceregexp  file="${dir}/sourceTest.r"
-                    match="\[SCRIPT\]"
-                    replace="${script-file}"
-                    flags="g"
-    />
-    <replaceregexp  file="${dir}/sourceTest.r"
-                    match="\[DIR_DDG\]"
-                    replace="${FILE.basedir}/${dir}/ddg"
-                    flags="g"
-    />
+		<!-- Copy the source test file to this directory, and replace with correct script name and directory -->
+		<copy file="${FILE.basedir}/tests/sourceTest.r" todir="${dir}" overwrite="true"/>
+		<replaceregexp  file="${dir}/sourceTest.r"
+						match="\[DIR_LOCAL\]"
+						replace="${FILE.basedir}/${dir}"
+						flags="g"
+		/>
+		<replaceregexp  file="${dir}/sourceTest.r"
+						match="\[SCRIPT\]"
+						replace="${script-file}"
+						flags="g"
+		/>
+		<replaceregexp  file="${dir}/sourceTest.r"
+						match="\[DIR_DDG\]"
+						replace="${FILE.basedir}/${dir}/ddg"
+						flags="g"
+		/>
 
-    <!-- Execute the R Script (delete ddg directory first) -->
-    <delete dir="${dir}/ddg" quiet="true" />
-    <exec executable="Rscript" dir="${dir}" output="${FILE.basedir}/${out}" >
-      <arg line="sourceTest.r" />
-    </exec>
+		<!-- Execute the R Script (delete ddg directory first) -->
+		<delete dir="${dir}/ddg" quiet="true" />
+		<exec executable="Rscript" dir="${dir}" output="${FILE.basedir}/${out}" >
+			<arg line="sourceTest.r" />
+		</exec>
 
-    <!-- Obtain name of expected ddg.json, expected *.out, and actual *.out -->
-    <basename property="ddg_name" file="${expected_ddg}" />
-    <basename property="expected_out_name" file="${expected_out}" />
-    <basename property="out_name" file="${out}" />
+		<!-- Obtain name of expected ddg.json, expected *.out, and actual *.out -->
+		<basename property="ddg_name" file="${expected_ddg}" />
+		<basename property="expected_out_name" file="${expected_out}" />
+		<basename property="out_name" file="${out}" />
 
-    <!-- Make copy of output files (.out and ddg.json) as well as expected
-         outputs for diff. Append .local to all files -->
-    <copy todir="${local_dir}" overwrite="true">
-      <!-- Executed ddg.json file -->
-      <fileset file="${dir}/ddg/ddg.json" />
-      <!-- all .out files and files ending in _ddg.json in the test directory -->
-      <fileset dir="${dir}">
-        <include name="*.out" />
-        <include name="*_ddg.json" />
-      </fileset>
-      <globmapper from="*" to="*.local"/>
-    </copy>
+		<!-- Make copy of output files (.out and ddg.json) as well as expected
+			 outputs for diff. Append .local to all files -->
+		<copy todir="${local_dir}" overwrite="true">
+			<!-- Executed ddg.json file -->
+			<fileset file="${dir}/ddg/ddg.json" />
+			<!-- all .out files and files ending in _ddg.json in the test directory -->
+			<fileset dir="${dir}">
+				<include name="*.out" />
+				<include name="*_ddg.json" />
+			</fileset>
+			<globmapper from="*" to="*.local"/>
+		</copy>
     
     
-    <!-- EF EDITs -->
-    <antcall target="prov-json-compliance-test" />
+		<!-- Test for prov-json compliance before edits to files are made for the diff -->
+		<antcall target="prov-json-compliance-test" />
     
 
-    <!-- Delete all local environment information (except sourced scripts & installed packages) -->
-    <replaceregexp flags="g">
-      <regexp pattern='(\t+("rdt:architecture"|"rdt:operatingSystem"|"rdt:language"|"rdt:rVersion"|"rdt:script"|"rdt:scriptTimeStamp"|"rdt:workingDirectory"|"rdt:ddgDirectory"|"rdt:SHA1hash"|"rdt:MD5hash"|"rdt:hash"|"rdt:ddgTimeStamp"|"rdt:rdatatrackerVersion"): (.*)\r?\n(,\r?\n)?)' />
-      <substitution expression=""/>
-      <fileset dir="${local_dir}">
-        <patternset id="local_files">
-          <include name="*.local" />
-        </patternset>
-      </fileset>
-    </replaceregexp>
+		<!-- Delete all local environment information (except sourced scripts & installed packages) -->
+		<replaceregexp flags="g">
+			<regexp pattern='(\t+("rdt:architecture"|"rdt:operatingSystem"|"rdt:language"|"rdt:rVersion"|"rdt:script"|"rdt:scriptTimeStamp"|"rdt:workingDirectory"|"rdt:ddgDirectory"|"rdt:SHA1hash"|"rdt:MD5hash"|"rdt:hash"|"rdt:ddgTimeStamp"|"rdt:rdatatrackerVersion"): (.*)\r?\n(,\r?\n)?)' />
+			<substitution expression=""/>
+			<fileset dir="${local_dir}">
+				<patternset id="local_files">
+					<include name="*.local" />
+				</patternset>
+			</fileset>
+		</replaceregexp>
 
-    <!-- 
-      Delete all sourced script timestamp occurrences
-      
-      There are 3 different cases:
-      "rdt:sourcedScriptTimeStamps": "",    // no additional sourced scripts
-      "rdt:sourcedScriptTimeStamps": ["2018-01-11T06.29.26EST"],    // 1 additional sourced script
-      
-      // multiple additional sourced scripts
-      "rdt:sourcedScriptTimeStamps": [
-        "2018-01-11T06.29.26EST",
-        "2018-01-11T06.29.26EST",
-        "2018-01-11T06.29.26EST",
-      ],    
-    -->
-    <replaceregexp flags="g">
-      <regexp pattern='(\t+"rdt:sourcedScriptTimeStamps": (""|\[\r?\n?(\t*"?([0-9]{4}-[0-9]{2}-[0-9]{2}(T| )[0-9]{2}(.|:)[0-9]{2}(.|:)[0-9]{2}[A-Z]{0,3}[+|-]?[0-9]{0,2})?"?,?\r?\n?)+\]),)' />
-      <substitution expression=""/>
-      <fileset dir="${local_dir}">
-        <patternset id="local_files">
-          <include name="*.local" />
-        </patternset>
-      </fileset>
-    </replaceregexp>
+		<!-- 
+			Delete all sourced script timestamp occurrences
+			
+			There are 3 different cases:
+			"rdt:sourcedScriptTimeStamps": "",    // no additional sourced scripts
+			"rdt:sourcedScriptTimeStamps": ["2018-01-11T06.29.26EST"],    // 1 additional sourced script
+			
+			// multiple additional sourced scripts
+			"rdt:sourcedScriptTimeStamps": [
+				"2018-01-11T06.29.26EST",
+				"2018-01-11T06.29.26EST",
+				"2018-01-11T06.29.26EST",
+			],    
+    	-->
+		<replaceregexp flags="g">
+			<regexp pattern='(\t+"rdt:sourcedScriptTimeStamps": (""|\[\r?\n?(\t*"?([0-9]{4}-[0-9]{2}-[0-9]{2}(T| )[0-9]{2}(.|:)[0-9]{2}(.|:)[0-9]{2}[A-Z]{0,3}[+|-]?[0-9]{0,2})?"?,?\r?\n?)+\]),)' />
+			<substitution expression=""/>
+			<fileset dir="${local_dir}">
+				<patternset id="local_files">
+					<include name="*.local" />
+				</patternset>
+			</fileset>
+		</replaceregexp>
 
-    <!-- Delete all entity timestamp occurrences -->
-    <replaceregexp flags="g">
-      <regexp pattern='(\t+"rdt:timestamp": ("?([0-9]{4}-[0-9]{2}-[0-9]{2}(T| )[0-9]{2}(.|:)[0-9]{2}(.|:)[0-9]{2}[A-Z]{0,3}[+|-]?[0-9]{0,2})?"?,)\r?\n)' />
-      <substitution expression=""/>
-      <fileset dir="${local_dir}">
-        <patternset id="local_files">
-          <include name="*.local" />
-        </patternset>
-      </fileset>
-    </replaceregexp>
+		<!-- Delete all entity timestamp occurrences -->
+		<replaceregexp flags="g">
+			<regexp pattern='(\t+"rdt:timestamp": ("?([0-9]{4}-[0-9]{2}-[0-9]{2}(T| )[0-9]{2}(.|:)[0-9]{2}(.|:)[0-9]{2}[A-Z]{0,3}[+|-]?[0-9]{0,2})?"?,)\r?\n)' />
+			<substitution expression=""/>
+			<fileset dir="${local_dir}">
+				<patternset id="local_files">
+					<include name="*.local" />
+				</patternset>
+			</fileset>
+		</replaceregexp>
 
-    <!-- Delete all entity scope occurrences  -->
-    <replaceregexp flags="g">
-      <regexp pattern='(\t+"rdt:scope": ("(.*)",)\r?\n)' />
-      <substitution expression=""/>
-      <fileset dir="${local_dir}">
-        <patternset id="local_files">
-          <include name="*.local" />
-        </patternset>
-      </fileset>
-    </replaceregexp>
+		<!-- Delete all entity scope occurrences  -->
+		<replaceregexp flags="g">
+			<regexp pattern='(\t+"rdt:scope": ("(.*)",)\r?\n)' />
+			<substitution expression=""/>
+			<fileset dir="${local_dir}">
+				<patternset id="local_files">
+					<include name="*.local" />
+				</patternset>
+			</fileset>
+		</replaceregexp>
 
-    <!-- Delete all activity elapsed time occurrences  -->
-    <replaceregexp flags="g">
-      <regexp pattern='(\t+"rdt:elapsedTime": ([0-9]*\.?[0-9]+,)\r?\n)' />
-      <substitution expression=""/>
-      <fileset dir="${local_dir}">
-        <patternset id="local_files">
-          <include name="*.local" />
-        </patternset>
-      </fileset>
-    </replaceregexp>
+		<!-- Delete all activity elapsed time occurrences  -->
+		<replaceregexp flags="g">
+			<regexp pattern='(\t+"rdt:elapsedTime": ([0-9]*\.?[0-9]+,)\r?\n)' />
+			<substitution expression=""/>
+			<fileset dir="${local_dir}">
+				<patternset id="local_files">
+					<include name="*.local" />
+				</patternset>
+			</fileset>
+		</replaceregexp>
 
-    <!-- Further edit the .local files if running tests on Travis -->
-    <antcall target="travis-edits"/>
+		<!-- Further edit the .local files if running tests on Travis -->
+		<antcall target="travis-edits"/>
 
-    <!-- Replace quotes on all local files -->
-    <replaceregexp flags="g">
-      <regexp pattern='\‘' />
-      <substitution expression="\'" />
-      <fileset dir="${local_dir}">
-        <patternset id="local_files">
-          <include name="*.local" />
-        </patternset>
-      </fileset>
-    </replaceregexp>
+		<!-- Replace quotes on all local files -->
+		<replaceregexp flags="g">
+			<regexp pattern='\‘' />
+			<substitution expression="\'" />
+			<fileset dir="${local_dir}">
+				<patternset id="local_files">
+					<include name="*.local" />
+				</patternset>
+			</fileset>
+		</replaceregexp>
 
-    <replaceregexp flags="g">
-      <regexp pattern='\’' />
-      <substitution expression="\'" />
-      <fileset dir="${local_dir}">
-        <patternset id="local_files">
-          <include name="*.local" />
-        </patternset>
-      </fileset>
-    </replaceregexp>
+		<replaceregexp flags="g">
+			<regexp pattern='\’' />
+			<substitution expression="\'" />
+			<fileset dir="${local_dir}">
+				<patternset id="local_files">
+					<include name="*.local" />
+				</patternset>
+			</fileset>
+		</replaceregexp>
 
-    <!-- Replace local file paths with [DIR] -->
-    <replaceregexp flags="g">
-      <regexp pattern="${FILE.basedir}/${dir}" />
-      <substitution expression="\[DIR\]"/>
-      <fileset dir="${local_dir}">
-        <patternset refid="local_files" />
-      </fileset>
-    </replaceregexp>
+		<!-- Replace local file paths with [DIR] -->
+		<replaceregexp flags="g">
+			<regexp pattern="${FILE.basedir}/${dir}" />
+			<substitution expression="\[DIR\]"/>
+			<fileset dir="${local_dir}">
+				<patternset refid="local_files" />
+			</fileset>
+		</replaceregexp>
 
-    <!-- Fix line endings on all local files so diff works well -->
-    <fixcrlf srcdir="${local_dir}"
-      includes="*.local"
-      eol="lf"
-      eof="remove"
-      tab="remove"
-      tablength="2"
-    />
+		<!-- Fix line endings on all local files so diff works well -->
+		<fixcrlf srcdir="${local_dir}"
+			includes="*.local"
+			eol="lf"
+			eof="remove"
+			tab="remove"
+			tablength="2"
+		/>
 
-    <!-- Execute diff on .out files (always)-->
-    <echo>
-      Diff of (1) ${out_name}.local and (2) ${expected_out_name}.local:
-    </echo>
+		<!-- Execute diff on .out files (always)-->
+    	<echo>
+	Diff of (1) ${out_name}.local and (2) ${expected_out_name}.local:
+    	</echo>
 
-    <exec executable="diff">
-      <arg line="--strip-trailing-cr ${local_dir}/${out_name}.local ${local_dir}/${expected_out_name}.local" />
-    </exec>
+		<exec executable="diff">
+			<arg line="--strip-trailing-cr ${local_dir}/${out_name}.local ${local_dir}/${expected_out_name}.local" />
+		</exec>
 
-    <!-- Exectute diff on .json files -->
-    <echo>
-      Diff of (1) ddg.json.local and (2) ${ddg_name}.local:
-    </echo>
+		<!-- Exectute diff on .json files -->
+		<echo>
+	Diff of (1) ddg.json.local and (2) ${ddg_name}.local:
+		</echo>
 
-    <exec executable="diff">
-      <arg line="--strip-trailing-cr ${local_dir}/ddg.json.local ${local_dir}/${ddg_name}.local" />
-    </exec>
+		<exec executable="diff">
+			<arg line="--strip-trailing-cr ${local_dir}/ddg.json.local ${local_dir}/${ddg_name}.local" />
+		</exec>
 
-    <echo>cmp (1) ddg.json.local and (2) ${ddg_name}.local:</echo>
+		<echo>cmp (1) ddg.json.local and (2) ${ddg_name}.local:</echo>
 
-    <exec executable="cmp" failonerror="false" resultproperty="return.code.out">
-      <arg value="${local_dir}/${out_name}.local" />
-      <arg value="${local_dir}/${expected_out_name}.local" />
-    </exec>
+		<exec executable="cmp" failonerror="false" resultproperty="return.code.out">
+			<arg value="${local_dir}/${out_name}.local" />
+			<arg value="${local_dir}/${expected_out_name}.local" />
+		</exec>
 
-    <exec executable="cmp" failonerror="false" resultproperty="return.code.json">
-      <arg value="${local_dir}/ddg.json.local" />
-      <arg value="${local_dir}/${ddg_name}.local" />
-    </exec>
+		<exec executable="cmp" failonerror="false" resultproperty="return.code.json">
+			<arg value="${local_dir}/ddg.json.local" />
+			<arg value="${local_dir}/${ddg_name}.local" />
+		</exec>
 
-    <!-- check for failure -->
-    <antcall target="failure-check"/>
+		<!-- Travis: Fails if a test does not pass -->
+		<fail message="Does not match expected output.">
+			<condition>
+				<and>
+					<equals arg1="${using-travis}" arg2="true" />
+					<or>
+						<equals arg1="${return.code.out}" arg2="1"/>
+						<equals arg1="${return.code.json}" arg2="1"/>
+					</or>
+				</and>
+			</condition>
+		</fail>
 
-  </target>
-
-
-  <!-- Travis: Further edits the .local files for tests -->
-  <target name="travis-edits" if="using-travis">
-
-    <!-- Remove environment node -->
-    <replaceregexp byline="false" flags="s">
-      <regexp pattern='(\t+// environment\r?\n\t+"environment": \{\r?\n(.*)},(\r?\n)+\t+//)' />
-      <substitution expression='(\t\t//)' />
-      <fileset dir="${local_dir}">
-        <patternset id="local_files">
-          <include name="*.local" />
-        </patternset>
-      </fileset>
-    </replaceregexp>
-    
-    <!-- remove library versions
-      some examples of library version strings:
-      "version": "1.5",
-      "version": 0.3.0",
-      "version": "3.98-1.10",
-      "version": "2.41-3",
-    -->
-    <replaceregexp flags="g">
-      <regexp pattern='(\t+"version": ("[0-9]+.?[0-9]*.?[0-9]*-?[0-9]*.?[0-9]*"),\r?\n)' />
-      <substitution expression=""/>
-      <fileset dir="${local_dir}">
-        <patternset id="local_files">
-          <include name="*.local" />
-        </patternset>
-      </fileset>
-    </replaceregexp>
-
-    <!-- remove execution time from .out.local files -->
-    <replaceregexp>
-      <regexp pattern='Execution Time = ([0-9]*\.[0-9]+)${line.separator}' />
-      <substitution expression='' />
-      <fileset dir="${local_dir}">
-        <patternset id="local_files">
-          <include name="*.out.local" />
-        </patternset>
-      </fileset>
-    </replaceregexp>
-
-  </target>
+	</target>
 
 
-  <!-- Travis: Fails if a test does not pass -->
-  <target name="failure-check" if="using-travis">
-    <fail message="Does not match expected output.">
-      <condition>
-        <or>
-          <equals arg1="${return.code.out}" arg2="1"/>
-          <equals arg1="${return.code.json}" arg2="1"/>
-        </or>
-      </condition>
-    </fail>
-  </target>
+	<!-- 
+		prov-json compliance test
+		Tests the produced .json file for prov-json compliance.
+	-->
+	<target name="prov-json-compliance-test">
+		<exec executable="Rscript" dir="tests/ProvJsonTest" resultproperty="compliant">
+			<arg value="ProvJsonTest.r" />
+			<arg path="tests/ProvJsonTest/schema.json" />
+			<arg path="${local_dir}/ddg.json.local" />
+		</exec>
+		<fail message="ddg.json is not prov-json compliant.">
+			<condition>
+				<and>
+					<equals arg1="${using-travis}" arg2="true" />
+					<equals arg1="${compliant}" arg2="1"/>
+				</and>
+			</condition>
+		</fail>
+	</target>
 
 
-  <!-- Runs a test using a standard file naming scheme. -->
-  <target name = "run-regression-test">
-    <antcall target="run-test">
-      <param name="dir" value="tests/${test-name}" />
-      <param name="out" value="tests/${test-name}/${test-name}.out" />
-      <param name="script-file" value="${test-name}.R" />
-      <param name="expected_out" value="tests/${test-name}/expected_${test-name}.out" />
-      <param name="expected_ddg" value="tests/${test-name}/expected_${test-name}_ddg.json" />
-    </antcall>
-  </target>
+	<!-- Travis: Further edits the .local files for tests -->
+	<target name="travis-edits" if="using-travis">
 
-  <target name = "run-regression-test-Rmd">
-    <antcall target="run-test">
-      <param name="dir" value="tests/${test-name}" />
-      <param name="out" value="tests/${test-name}/${test-name}.out" />
-      <param name="script-file" value="${test-name}.Rmd" />
-      <param name="expected_out" value="tests/${test-name}/expected_${test-name}.out" />
-      <param name="expected_ddg" value="tests/${test-name}/expected_${test-name}_ddg.json" />
-    </antcall>
-  </target>
+		<!-- Remove environment node -->
+		<replaceregexp byline="false" flags="s">
+			<regexp pattern='(\t+// environment\r?\n\t+"environment": \{\r?\n(.*)},(\r?\n)+\t+//)' />
+			<substitution expression='(\t\t//)' />
+			<fileset dir="${local_dir}">
+				<patternset id="local_files">
+					<include name="*.local" />
+				</patternset>
+			</fileset>
+		</replaceregexp>
+		
+		<!-- remove library versions
+			some examples of library version strings:
+			"version": "1.5",
+			"version": 0.3.0",
+			"version": "3.98-1.10",
+			"version": "2.41-3",
+		-->
+		<replaceregexp flags="g">
+			<regexp pattern='(\t+"version": ("[0-9]+.?[0-9]*.?[0-9]*-?[0-9]*.?[0-9]*"),\r?\n)' />
+			<substitution expression=""/>
+			<fileset dir="${local_dir}">
+				<patternset id="local_files">
+					<include name="*.local" />
+				</patternset>
+			</fileset>
+		</replaceregexp>
 
+		<!-- remove execution time from .out.local files -->
+		<replaceregexp>
+			<regexp pattern='Execution Time = ([0-9]*\.[0-9]+)${line.separator}' />
+			<substitution expression='' />
+			<fileset dir="${local_dir}">
+				<patternset id="local_files">
+					<include name="*.out.local" />
+				</patternset>
+			</fileset>
+		</replaceregexp>
 
-  <!-- Updates the expected result files for a test case. -->
-  <!-- This should only be used when the expected results have changed for the better! -->
-  <target name="update-expected">
-    <!-- Confirm that the user wants to update the expected results.  -->
-    <input
-        message="Do you want to update the expected results for ${dir}?"
-        validargs="y,n"
-        addproperty="do.update"
-    />
-    <condition property="do.abort">
-      <not>
-        <equals arg1="y" arg2="${do.update}"/>
-      </not>
-    </condition>
-    <fail if="do.abort">Update aborted by user.</fail>
-
-    <!-- Directory to store expected results while editing -->
-    <property name="expected_dir" value="${dir}/expected" />
-    <delete dir="${expected_dir}" quiet="true" />
-    <mkdir dir="${expected_dir}" />
-
-    <!-- Make copy of ddg.json and the .out file into the expected folder -->
-    <copy todir="${expected_dir}" overwrite="true">
-      <!-- Executed ddg.json file -->
-      <fileset file="${dir}/ddg/ddg.json" />
-      <fileset file="${FILE.basedir}/${out}" />
-    </copy>
-
-    <!-- Replace local file paths with [DIR] -->
-    <replaceregexp flags="g">
-      <regexp pattern="${FILE.basedir}/${dir}" />
-      <substitution expression="\[DIR\]"/>
-      <fileset dir="${expected_dir}" />
-    </replaceregexp>
-
-    <!-- Move the edited files up to become the new expected results -->
-    <copy file="${expected_dir}/ddg.json" tofile="${expected_ddg}" overwrite="true" />
-    <basename property="out_name" file="${out}" />
-    <copy file="${expected_dir}/${out_name}" tofile="${expected_out}" overwrite="true" />
-  </target>
+	</target>
 
 
-  <!-- Task to update the expected results using the standard naming scheme -->
-  <target name = "update-regression-expected">
-    <antcall target="update-expected">
-      <param name="dir" value="tests/${test-name}"/>
-      <param name="out" value="tests/${test-name}/${test-name}.out"/>
-      <param name="expected_out" value="tests/${test-name}/expected_${test-name}.out"/>
-      <param name="expected_ddg" value="tests/${test-name}/expected_${test-name}_ddg.json"/>
-    </antcall>
-  </target>
+	<!-- Runs a test using a standard file naming scheme. -->
+	<target name = "run-regression-test">
+		<antcall target="run-test">
+			<param name="dir" value="tests/${test-name}" />
+			<param name="out" value="tests/${test-name}/${test-name}.out" />
+			<param name="script-file" value="${test-name}.R" />
+			<param name="expected_out" value="tests/${test-name}/expected_${test-name}.out" />
+			<param name="expected_ddg" value="tests/${test-name}/expected_${test-name}_ddg.json" />
+		</antcall>
+	</target>
 
-  <!--############################ End FUNCTIONS ############################-->
+	<target name = "run-regression-test-Rmd">
+		<antcall target="run-test">
+			<param name="dir" value="tests/${test-name}" />
+			<param name="out" value="tests/${test-name}/${test-name}.out" />
+			<param name="script-file" value="${test-name}.Rmd" />
+			<param name="expected_out" value="tests/${test-name}/expected_${test-name}.out" />
+			<param name="expected_ddg" value="tests/${test-name}/expected_${test-name}_ddg.json" />
+		</antcall>
+	</target>
 
 
-  <!--########################## Start Basic TESTS ##########################-->
+	<!-- Updates the expected result files for a test case. -->
+	<!-- This should only be used when the expected results have changed for the better! -->
+	<target name="update-expected">
+		<!-- Confirm that the user wants to update the expected results.  -->
+		<input
+			message="Do you want to update the expected results for ${dir}?"
+			validargs="y,n"
+			addproperty="do.update"
+		/>
+		<condition property="do.abort">
+			<not>
+				<equals arg1="y" arg2="${do.update}"/>
+			</not>
+		</condition>
+		<fail if="do.abort">Update aborted by user.</fail>
 
-  	<target name="basicTest">
-  		<antcall target="run-regression-test">
+		<!-- Directory to store expected results while editing -->
+		<property name="expected_dir" value="${dir}/expected" />
+		<delete dir="${expected_dir}" quiet="true" />
+		<mkdir dir="${expected_dir}" />
+
+		<!-- Make copy of ddg.json and the .out file into the expected folder -->
+		<copy todir="${expected_dir}" overwrite="true">
+			<!-- Executed ddg.json file -->
+			<fileset file="${dir}/ddg/ddg.json" />
+			<fileset file="${FILE.basedir}/${out}" />
+		</copy>
+
+		<!-- Replace local file paths with [DIR] -->
+		<replaceregexp flags="g">
+			<regexp pattern="${FILE.basedir}/${dir}" />
+			<substitution expression="\[DIR\]"/>
+			<fileset dir="${expected_dir}" />
+		</replaceregexp>
+
+		<!-- Move the edited files up to become the new expected results -->
+		<copy file="${expected_dir}/ddg.json" tofile="${expected_ddg}" overwrite="true" />
+		<basename property="out_name" file="${out}" />
+		<copy file="${expected_dir}/${out_name}" tofile="${expected_out}" overwrite="true" />
+	</target>
+
+
+	<!-- Task to update the expected results using the standard naming scheme -->
+	<target name = "update-regression-expected">
+		<antcall target="update-expected">
+			<param name="dir" value="tests/${test-name}"/>
+			<param name="out" value="tests/${test-name}/${test-name}.out"/>
+			<param name="expected_out" value="tests/${test-name}/expected_${test-name}.out"/>
+			<param name="expected_ddg" value="tests/${test-name}/expected_${test-name}_ddg.json"/>
+		</antcall>
+	</target>
+
+	<!--############################ End FUNCTIONS ############################-->
+	
+	<!-- 
+		ProvJsonTest 
+		Ensures jsonvalidate's json_validate function performs as expected.
+		This runs before basicTest when test-travis and test-all are called. 
+	-->
+	<target name="ProvJsonTest">
+		<exec executable="Rscript" dir="tests/ProvJsonTest" resultproperty="passed">
+			<arg value="ProvJsonTest.r" />
+		</exec>
+		<fail message="Test failed.">
+			<condition>
+				<and>
+					<equals arg1="${using-travis}" arg2="true" />
+					<equals arg1="${passed}" arg2="1" />
+				</and>
+			</condition>
+		</fail>
+	</target>
+
+	<!--########################## Start Basic TESTS ##########################-->
+
+	<target name="basicTest">
+		<antcall target="run-regression-test">
   			<param name="test-name" value="basicTest" />
   		</antcall>
   	</target>
 
 	<target name="update-basicTest">
-	  <antcall target="update-regression-expected">
-	  	<param name="test-name" value="basicTest" />
-	 	</antcall>
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="basicTest" />
+		</antcall>
 	</target>
 
-  	<target name="S4ObjectTest">
-  		<antcall target="run-regression-test">
-  			<param name="test-name" value="S4ObjectTest" />
-  		</antcall>
-  	</target>
+	<target name="S4ObjectTest">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="S4ObjectTest" />
+		</antcall>
+	</target>
 
 	<target name="update-S4ObjectTest">
-	  <antcall target="update-regression-expected">
-	  	<param name="test-name" value="S4ObjectTest" />
-	 	</antcall>
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="S4ObjectTest" />
+		</antcall>
 	</target>
 
-  	<target name="ScopeTest">
-  		<antcall target="run-regression-test">
-  			<param name="test-name" value="ScopeTest" />
-  		</antcall>
-  	</target>
+	<target name="ScopeTest">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="ScopeTest" />
+		</antcall>
+	</target>
 
 	<target name="update-ScopeTest">
-	  <antcall target="update-regression-expected">
-	  	<param name="test-name" value="ScopeTest" />
-	 	</antcall>
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="ScopeTest" />
+		</antcall>
 	</target>
 
-  	<target name="ReturnTest">
-  		<antcall target="run-regression-test">
-  			<param name="test-name" value="ReturnTest" />
-  		</antcall>
-  	</target>
+	<target name="ReturnTest">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="ReturnTest" />
+		</antcall>
+	</target>
 
 	<target name="update-ReturnTest">
-	  <antcall target="update-regression-expected">
-	  	<param name="test-name" value="ReturnTest" />
-	 	</antcall>
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="ReturnTest" />
+		</antcall>
 	</target>
 
-  	<target name="OddParameterTest">
-  		<antcall target="run-regression-test">
-  			<param name="test-name" value="OddParameterTest" />
-  		</antcall>
-  	</target>
+	<target name="OddParameterTest">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="OddParameterTest" />
+		</antcall>
+	</target>
 
 	<target name="update-OddParameterTest">
-	  <antcall target="update-regression-expected">
-	  	<param name="test-name" value="OddParameterTest" />
-	 	</antcall>
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="OddParameterTest" />
+		</antcall>
 	</target>
 
-  	<target name="FunctionAnnotationTest">
-  		<antcall target="run-regression-test">
-  			<param name="test-name" value="FunctionAnnotationTest" />
-  		</antcall>
-  	</target>
+	<target name="FunctionAnnotationTest">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="FunctionAnnotationTest" />
+		</antcall>
+	</target>
 
 	<target name="update-FunctionAnnotationTest">
-	  <antcall target="update-regression-expected">
-	  	<param name="test-name" value="FunctionAnnotationTest" />
-	 	</antcall>
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="FunctionAnnotationTest" />
+		</antcall>
 	</target>
 
-  <target name="AnnotateOnOffTest">
-    <antcall target="run-regression-test">
-      <param name="test-name" value="AnnotateOnOffTest" />
-    </antcall>
-  </target>
+	<target name="AnnotateOnOffTest">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="AnnotateOnOffTest" />
+		</antcall>
+	</target>
 
-  <target name="update-AnnotateOnOffTest">
-    <antcall target="update-regression-expected">
-      <param name="test-name" value="AnnotateOnOffTest" />
-    </antcall>
-  </target>
+	<target name="update-AnnotateOnOffTest">
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="AnnotateOnOffTest" />
+		</antcall>
+	</target>
 
 	<target name="ControlConstructTest">
 		<antcall target="run-regression-test">
@@ -584,59 +620,59 @@
 		</antcall>
 	</target>
 
-  	<target name="WarningTest">
-  		<antcall target="run-regression-test">
-  			<param name="test-name" value="WarningTest" />
-  		</antcall>
-  	</target>
+	<target name="WarningTest">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="WarningTest" />
+		</antcall>
+	</target>
 
 	<target name="update-WarningTest">
-	  <antcall target="update-regression-expected">
-	  	<param name="test-name" value="WarningTest" />
-	 	</antcall>
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="WarningTest" />
+		</antcall>
 	</target>
 
-  	<target name="PlotTest">
-  		<antcall target="run-regression-test">
-  			<param name="test-name" value="PlotTest" />
-  		</antcall>
-  	</target>
+	<target name="PlotTest">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="PlotTest" />
+		</antcall>
+	</target>
 
 	<target name="update-PlotTest">
-	  <antcall target="update-regression-expected">
-	  	<param name="test-name" value="PlotTest" />
-	 	</antcall>
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="PlotTest" />
+		</antcall>
 	</target>
 
-  	<target name="Plot2Test">
-  		<antcall target="run-regression-test">
-  			<param name="test-name" value="Plot2Test" />
-  		</antcall>
-  	</target>
+	<target name="Plot2Test">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="Plot2Test" />
+		</antcall>
+	</target>
 
 	<target name="update-Plot2Test">
-	  <antcall target="update-regression-expected">
-	  	<param name="test-name" value="Plot2Test" />
-	 	</antcall>
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="Plot2Test" />
+		</antcall>
 	</target>
 
-    <target name="NoDevOffTest">
-      <antcall target="run-regression-test">
-        <param name="test-name" value="NoDevOffTest" />
-      </antcall>
-    </target>
+	<target name="NoDevOffTest">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="NoDevOffTest" />
+		</antcall>
+	</target>
 
-  <target name="update-NoDevOffTest">
-    <antcall target="update-regression-expected">
-      <param name="test-name" value="NoDevOffTest" />
-    </antcall>
-  </target>
+	<target name="update-NoDevOffTest">
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="NoDevOffTest" />
+		</antcall>
+	</target>
 
-  	<target name="DataTypeTest">
-  		<antcall target="run-regression-test">
-  			<param name="test-name" value="DataTypeTest" />
-  		</antcall>
-  	</target>
+	<target name="DataTypeTest">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="DataTypeTest" />
+		</antcall>
+	</target>
 
 	<target name="update-DataTypeTest">
 		<antcall target="update-regression-expected">
@@ -644,23 +680,23 @@
 		</antcall>
 	</target>
 
-  	<target name="HigherOrderFuncTest">
-  		<antcall target="run-regression-test">
-  			<param name="test-name" value="HigherOrderFuncTest" />
-  		</antcall>
-  	</target>
+	<target name="HigherOrderFuncTest">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="HigherOrderFuncTest" />
+		</antcall>
+	</target>
 
 	<target name="update-HigherOrderFuncTest">
-	  <antcall target="update-regression-expected">
-	  	<param name="test-name" value="HigherOrderFuncTest" />
-	 	</antcall>
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="HigherOrderFuncTest" />
+		</antcall>
 	</target>
     
-    <target name="AssignmentOperatorsTest">
-		  <antcall target="run-regression-test">
-			 <param name="test-name" value="AssignmentOperatorsTest" />
-		  </antcall>
-    </target>
+	<target name="AssignmentOperatorsTest">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="AssignmentOperatorsTest" />
+		</antcall>
+	</target>
 
 	<target name="update-AssignmentOperatorsTest">
 		<antcall target="update-regression-expected">
@@ -668,400 +704,380 @@
 		</antcall>
 	</target>
   
-    <target name="FunctionOriginTest">
-      <antcall target="run-regression-test">
-        <param name="test-name" value="FunctionOriginTest" />
-      </antcall>
-    </target>
+	<target name="FunctionOriginTest">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="FunctionOriginTest" />
+		</antcall>
+	</target>
 
-  <target name="update-FunctionOriginTest">
-    <antcall target="update-regression-expected">
-      <param name="test-name" value="FunctionOriginTest" />
-    </antcall>
-  </target>
+	<target name="update-FunctionOriginTest">
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="FunctionOriginTest" />
+		</antcall>
+	</target>
 
-  	<target name="DDGStatementTest">
-  		<antcall target="run-regression-test">
-  			<param name="test-name" value="DDGStatementTest" />
-  		</antcall>
-  	</target>
+	<target name="DDGStatementTest">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="DDGStatementTest" />
+		</antcall>
+	</target>
 
 	<target name="update-DDGStatementTest">
-	  <antcall target="update-regression-expected">
-	  	<param name="test-name" value="DDGStatementTest" />
-	 	</antcall>
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="DDGStatementTest" />
+		</antcall>
 	</target>
 
-  	<target name="ConnectionTest">
-  		<antcall target="run-regression-test">
-  			<param name="test-name" value="ConnectionTest" />
-  		</antcall>
-  	</target>
+	<target name="ConnectionTest">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="ConnectionTest" />
+		</antcall>
+	</target>
 
 	<target name="update-ConnectionTest">
-	  <antcall target="update-regression-expected">
-	  	<param name="test-name" value="ConnectionTest" />
-	 	</antcall>
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="ConnectionTest" />
+		</antcall>
 	</target>
 
-    <target name="RMarkdownTest">
-      <antcall target="run-regression-test-Rmd">
-        <param name="test-name" value="RMarkdownTest" />
-      </antcall>
-    </target>
+	<target name="RMarkdownTest">
+		<antcall target="run-regression-test-Rmd">
+			<param name="test-name" value="RMarkdownTest" />
+		</antcall>
+	</target>
 
 	<target name="update-RMarkdownTest">
-    <antcall target="update-regression-expected">
-      <param name="test-name" value="RMarkdownTest" />
- 	  </antcall>
-
-  </target>
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="RMarkdownTest" />
+		</antcall>
+	</target>
 
 	<target name="normal-tests" depends="basicTest, S4ObjectTest,
 		ScopeTest, ReturnTest, OddParameterTest, FunctionAnnotationTest,
 		ControlConstructTest, WarningTest, PlotTest, Plot2Test, NoDevOffTest, DataTypeTest,
 		HigherOrderFuncTest, AssignmentOperatorsTest, FunctionOriginTest,
-    RMarkdownTest, DDGStatementTest, ConnectionTest">
+		RMarkdownTest, DDGStatementTest, ConnectionTest">
+		
 		<echo>
+	##############################################
+	Finished Execution of Normal Tests. Nothing should have malfunctioned.
+	##############################################
+    	</echo>
+	</target>
+
+	<!--########################## End Basic TESTS ##########################-->
+
+
+	<!--########################## Start Checkpoint TESTS ##########################-->
+
+	<target name="CheckpointTest">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="CheckpointTest" />
+		</antcall>
+	</target>
+
+	<target name="update-CheckpointTest">
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="CheckpointTest" />
+		</antcall>
+	</target>
+
+	<target name="CheckpointFileTest">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="CheckpointFileTest" />
+		</antcall>
+	</target>
+
+	<target name="update-CheckpointFileTest">
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="CheckpointFileTest" />
+		</antcall>
+	</target>
+
+	<target name="checkpoint-tests" depends="CheckpointTest, CheckpointFileTest">
+		<echo>
+	##############################################
+	Finished Execution of Checkpoint Tests. Expect differences in output for checkpoint-file-test due to directory creation in Windows (using : and spaces).
+	##############################################
+		</echo>
+	</target>
+
+	<!--########################## End Checkpoint TESTS ##########################-->
+
+	<!--########################## Start Source Tests ##########################-->
+
+	<target name="SourceFuncTest">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="SourceFuncTest" />
+		</antcall>
+	</target>
+
+	<target name="update-SourceFuncTest">
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="SourceFuncTest" />
+		</antcall>
+	</target>
+
+	<target name="OnOffTest">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="OnOffTest" />
+		</antcall>
+	</target>
+
+	<target name="update-OnOffTest">
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="OnOffTest" />
+		</antcall>
+	</target>
+
+	<!--<target name="source-tests" depends="SourceFuncTest, OnOffTest">-->
+	<target name="source-tests" depends="SourceFuncTest">
+		<echo>Finished Execution of Source Tests.</echo>
+	</target>
+
+	<!--########################## End Source TESTS ##########################-->
+
+
+	<!--########################## Start Script Tests ##########################-->
+
+	<target name="CalculateSquareRoot">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="CalculateSquareRoot" />
+		</antcall>
+	</target>
+
+	<target name="update-CalculateSquareRoot">
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="CalculateSquareRoot" />
+		</antcall>
+	</target>
+
+	<target name="DailySolarRadiation">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="DailySolarRadiation" />
+		</antcall>
+	</target>
+
+	<target name="update-DailySolarRadiation">
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="DailySolarRadiation" />
+		</antcall>
+	</target>
+
+	<target name="HFDatasetPreview">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="HFDatasetPreview" />
+		</antcall>
+		<echo>The test requires RCurl and gplots (+ dependencies) to be installed.</echo>
+	</target>
+
+	<target name="update-HFDatasetPreview">
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="HFDatasetPreview" />
+		</antcall>
+	</target>
+
+	<target name="SivanSamplingSmaller">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="SivanSamplingSmaller" />
+		</antcall>
+		<echo>This script uses randomization.</echo>
+	</target>
+
+	<target name="update-SivanSamplingSmaller">
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="SivanSamplingSmaller" />
+		</antcall>
+	</target>
+
+	<!-- SivanSampling is not currently included in the test suites because it collects too much data -->
+	<target name="SivanSampling">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="SivanSampling" />
+		</antcall>
+		<echo>This script uses randomization.</echo>
+	</target>
+
+	<target name="update-SivanSampling">
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="SivanSampling" />
+		</antcall>
+	</target>
+
+	<target name="script-tests" depends="CalculateSquareRoot, DailySolarRadiation, HFDatasetPreview">
+		<echo>Script tests for which output should not differ </echo>
+	</target>
+
+	<!--########################## End Script Tests ##########################-->
+
+
+	<!--########################## Start Interactive Tests ##########################-->
+
+	<target name="RealTime15MinMET">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="RealTime15MinMET" />
+		</antcall>
+	</target>
+
+	<target name="update-RealTime15MinMET">
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="RealTime15MinMET" />
+		</antcall>
+	</target>
+
+	<target name="QualityControl15Min">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="QualityControl15Min" />
+		</antcall>
+	</target>
+
+	<target name="update-QualityControl15Min">
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="QualityControl15Min" />
+		</antcall>
+	</target>
+
+	<target name="interactive-tests" depends="RealTime15MinMET, QualityControl15Min">
+		<echo>Script tests for which the user needs to provide input </echo>
+	</target>
+
+	<target name="AaronSimesDendrochronology">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="AaronSimesDendrochronology" />
+		</antcall>
+	</target>
+
+	<target name="update-AaronSimesDendrochronology">
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="AaronSimesDendrochronology" />
+		</antcall>
+	</target>
+
+	<target name="long-script-tests" depends="AaronSimesDendrochronology" >
+		<echo>Long tests derived from real-world scripts. </echo>
+	</target>
+
+	<!--########################## End Interactive Tests ##########################-->
+
+
+	<!--########################## Start Bug Tests ##########################-->
+
+	<target name="ddgDeepNesting">
+		<antcall target="run-regression-test">
+			<param name="test-name" value="ddgDeepNesting" />
+		</antcall>
+	</target>
+
+	<target name="update-ddgDeepNesting">
+		<antcall target="update-regression-expected">
+			<param name="test-name" value="ddgDeepNesting" />
+		</antcall>
+	</target>
+
+	<target name="bug-tests" depends="ddgDeepNesting" >
+		<echo>Tests which were added to check for specific bug fixes </echo>
+	</target>
+
+	<!--########################## End Bug Tests ##########################-->
+
+
+	<!--################################# MAIN #################################-->
+
+	<target name="quick-test" depends="normal-tests, source-tests, bug-tests" description="Run quick regressions tests for the currently installed RDataTracker Package.">
+		<echo>This batch of tests is quick to execute, but not as extensive.</echo>
+	</target>
+
+	<target name="long-test" depends="script-tests" description="Run long regression tests for the currently installed RDataTracker Package.">
+		<echo>This batch of tests takes longer, but is a bit more real-world.</echo>
+	</target>
+
+	<!-- Target for tests run by people -->
+	<target name="test-all" depends="ProvJsonTest, quick-test, long-test" description="Run all regression tests for the currently installed RDataTracker Package.">
+		<echo>All tests makes calls to the RDataTracker Library. You might need to restart RStudio to correctly run the scripts with the updated library installed. Output is saved in tests.log.</echo>
+	</target>
+
+	<!-- Target for tests run by Travis -->
+	<target name="test-travis" description="Runs all regression tests for the currently installed RDataTracker Package on Travis.">
+		<property name="using-travis" value="true"/>
+		<antcall target="ProvJsonTest"/>
+		<antcall target="quick-test"/>
+		<antcall target="long-test"/>
+		<echo>All tests makes calls to the RDataTracker Library. You might need to restart RStudio to correctly run the scripts with the updated library installed. Output is saved in tests.log.</echo>
+	</target>
+
+	<target name="install-and-test" description="Install the RDataTracker Package and perform all normal regression tests.">
+		<splash displaytext="Installing and Testing" />
+		<record name="tests.log" action="start" />
+		<antcall target="test-all" />
+		<record name="tests.log" action="stop" />
+	</target>
+
+	<!--################################# END MAIN #################################-->
+
+
+	<!--################################# UTILIES #################################-->
+
+	<!-- Test interactive() function when calling from command line -->
+	<target name="interactive-test">
+		<exec executable="Rscript" dir="tests" >
+			<arg line="RscriptTest.r" />
+		</exec>
+	</target>
+
+	<!-- Execute the script timer, which looks in the examples/ directory for all
+		files with a (-clear.r) suffix and a (template_)*(-annotated.r) pattern and
+		combined matching pairs to create a timing test. It executes a clean version of
+		the script, then minimally annotated the clean version and executes a console
+		and source version, and finally executes the annotated version.
+
+		This data is saved in the examples/_timingResults/ directory under the data/time
+		of execution.
+	-->
+	<target name="script-timer" depends="dependencies">
+		<splash displaytext="Running Performance Tests" />
+		<!-- Replace base.dir with the base directory of the project -->
+		<replaceregexp  file="utilities/scriptTimer.r"
+						match="base.dir &lt;- (.*)"
+						replace='base.dir &lt;- "${FILE.basedir}"'
+		/>
+		<record name="script-timer.log" action="start" />
+			<exec executable="Rscript" dir="utilities">
+				<arg line="scriptTimer.r execute" />
+			</exec>
+		<record name="script-timer.log" action="stop" />
+	</target>
+
+	<!-- Executes the same as above, but logs a lot more information on each
+		 script -->
+	<target name="script-timer-debug" depends="dependencies">
+		<replaceregexp  file="utilities/scriptTimer.r"
+						match="base.dir &lt;- (.*)"
+						replace='base.dir &lt;- "${FILE.basedir}"'
+		/>
+		<record name="script-timer-debug.log" action="start" />
+			<exec executable="Rscript" dir="utilities">
+				<arg line="scriptTimer.r execute debug" />
+			</exec>
+		<record name="script-timer-debug.log" action="stop" />
+	</target>
+
+	<!-- Executes utilities/plot.r. Within this file, scriptTimer.r is executed (making the above
+		 and unnecessary dependence).
+	-->
+	<target name="performance-report" depends="dependencies" description="Execute performance scripts on the current version of the library and generate a report.">
+		<splash displaytext="Creating Performance Report."/>
+		<!-- Replace base.dir with the base directory of the project -->
+		<replaceregexp  file="utilities/plot.r"
+						match="base.dir &lt;- (.*)"
+						replace='base.dir &lt;- "${FILE.basedir}"'
+		/>
+		<record name="plot-performance.log" action="start" />
+		<exec executable="Rscript" dir="utilities">
+			<arg line="plot.r plot _plots" />
+		</exec>
+		<record name="plot-performance.log" action="stop" />
+	</target>
+
+	<!--################################# END UTILIES #################################-->
 
-      ##############################################
-      Finished Execution of Normal Tests. Nothing should have malfunctioned.
-      ##############################################
-    </echo>
-  </target>
-
-  <!--########################## End Basic TESTS ##########################-->
-
-
-  <!--########################## Start Checkpoint TESTS ##########################-->
-
-  <target name="CheckpointTest">
-    <antcall target="run-regression-test">
-      <param name="test-name" value="CheckpointTest" />
-    </antcall>
-  </target>
-
-  <target name="update-CheckpointTest">
-    <antcall target="update-regression-expected">
-      <param name="test-name" value="CheckpointTest" />
-    </antcall>
-  </target>
-
-  <target name="CheckpointFileTest">
-    <antcall target="run-regression-test">
-      <param name="test-name" value="CheckpointFileTest" />
-    </antcall>
-  </target>
-
-  <target name="update-CheckpointFileTest">
-    <antcall target="update-regression-expected">
-      <param name="test-name" value="CheckpointFileTest" />
-    </antcall>
-  </target>
-
-  <target name="checkpoint-tests" depends="CheckpointTest, CheckpointFileTest">
-    <echo>
-      ##############################################
-      Finished Execution of Checkpoint Tests. Expect differences in output for checkpoint-file-test due to directory creation in Windows (using : and spaces).
-      ##############################################
-    </echo>
-  </target>
-
-  <!--########################## End Checkpoint TESTS ##########################-->
-
-  <!--########################## Start Source Tests ##########################-->
-
-  <target name="SourceFuncTest">
-    <antcall target="run-regression-test">
-      <param name="test-name" value="SourceFuncTest" />
-    </antcall>
-  </target>
-
-  <target name="update-SourceFuncTest">
-    <antcall target="update-regression-expected">
-      <param name="test-name" value="SourceFuncTest" />
-    </antcall>
-  </target>
-
-  <target name="OnOffTest">
-    <antcall target="run-regression-test">
-      <param name="test-name" value="OnOffTest" />
-    </antcall>
-  </target>
-
-  <target name="update-OnOffTest">
-    <antcall target="update-regression-expected">
-      <param name="test-name" value="OnOffTest" />
-    </antcall>
-  </target>
-
-  <!--<target name="source-tests" depends="SourceFuncTest, OnOffTest">-->
-  <target name="source-tests" depends="SourceFuncTest">
-    <echo>Finished Execution of Source Tests.</echo>
-  </target>
-
-  <!--########################## End Source TESTS ##########################-->
-
-
-  <!--########################## Start Script Tests ##########################-->
-
-  <target name="CalculateSquareRoot">
-    <antcall target="run-regression-test">
-      <param name="test-name" value="CalculateSquareRoot" />
-    </antcall>
-  </target>
-
-  <target name="update-CalculateSquareRoot">
-    <antcall target="update-regression-expected">
-      <param name="test-name" value="CalculateSquareRoot" />
-    </antcall>
-  </target>
-
-  <target name="DailySolarRadiation">
-    <antcall target="run-regression-test">
-      <param name="test-name" value="DailySolarRadiation" />
-    </antcall>
-  </target>
-
-  <target name="update-DailySolarRadiation">
-    <antcall target="update-regression-expected">
-      <param name="test-name" value="DailySolarRadiation" />
-    </antcall>
-  </target>
-
-  <target name="HFDatasetPreview">
-    <antcall target="run-regression-test">
-      <param name="test-name" value="HFDatasetPreview" />
-    </antcall>
-    <echo>The test requires RCurl and gplots (+ dependencies) to be installed.</echo>
-  </target>
-
-  <target name="update-HFDatasetPreview">
-    <antcall target="update-regression-expected">
-      <param name="test-name" value="HFDatasetPreview" />
-    </antcall>
-  </target>
-
-  <target name="SivanSamplingSmaller">
-    <antcall target="run-regression-test">
-      <param name="test-name" value="SivanSamplingSmaller" />
-    </antcall>
-    <echo>This script uses randomization.</echo>
-  </target>
-
-  <target name="update-SivanSamplingSmaller">
-    <antcall target="update-regression-expected">
-      <param name="test-name" value="SivanSamplingSmaller" />
-    </antcall>
-  </target>
-
-  <!-- SivanSampling is not currently included in the test suites because it collects too much data -->
-  <target name="SivanSampling">
-    <antcall target="run-regression-test">
-      <param name="test-name" value="SivanSampling" />
-    </antcall>
-    <echo>This script uses randomization.</echo>
-  </target>
-
-  <target name="update-SivanSampling">
-    <antcall target="update-regression-expected">
-      <param name="test-name" value="SivanSampling" />
-    </antcall>
-  </target>
-
-  <target name="script-tests" depends="CalculateSquareRoot, DailySolarRadiation, HFDatasetPreview">
-    <echo>Script tests for which output should not differ </echo>
-  </target>
-
-  <!--########################## End Script Tests ##########################-->
-
-
-  <!--########################## Start Interactive Tests ##########################-->
-
-  <target name="RealTime15MinMET">
-    <antcall target="run-regression-test">
-      <param name="test-name" value="RealTime15MinMET" />
-    </antcall>
-  </target>
-
-  <target name="update-RealTime15MinMET">
-    <antcall target="update-regression-expected">
-      <param name="test-name" value="RealTime15MinMET" />
-    </antcall>
-  </target>
-
-  <target name="QualityControl15Min">
-    <antcall target="run-regression-test">
-      <param name="test-name" value="QualityControl15Min" />
-    </antcall>
-  </target>
-
-  <target name="update-QualityControl15Min">
-    <antcall target="update-regression-expected">
-      <param name="test-name" value="QualityControl15Min" />
-    </antcall>
-  </target>
-
-  <target name="interactive-tests" depends="RealTime15MinMET, QualityControl15Min">
-    <echo>Script tests for which the user needs to provide input </echo>
-  </target>
-
-  <target name="AaronSimesDendrochronology">
-    <antcall target="run-regression-test">
-      <param name="test-name" value="AaronSimesDendrochronology" />
-    </antcall>
-  </target>
-
-  <target name="update-AaronSimesDendrochronology">
-    <antcall target="update-regression-expected">
-      <param name="test-name" value="AaronSimesDendrochronology" />
-    </antcall>
-  </target>
-
-  <target name="long-script-tests" depends="AaronSimesDendrochronology" >
-    <echo>Long tests derived from real-world scripts. </echo>
-  </target>
-
-  <!--########################## End Interactive Tests ##########################-->
-
-
-  <!--########################## Start Bug Tests ##########################-->
-
-  <target name="ddgDeepNesting">
-    <antcall target="run-regression-test">
-      <param name="test-name" value="ddgDeepNesting" />
-    </antcall>
-  </target>
-
-  <target name="update-ddgDeepNesting">
-    <antcall target="update-regression-expected">
-      <param name="test-name" value="ddgDeepNesting" />
-    </antcall>
-  </target>
-
-  <target name="bug-tests" depends="ddgDeepNesting" >
-    <echo>Tests which were added to check for specific bug fixes </echo>
-  </target>
-
-  <!--########################## End Bug Tests ##########################-->
-
-
-  <!--################################# MAIN #################################-->
-
-  <target name="quick-test" depends="normal-tests, source-tests, bug-tests" description="Run quick regressions tests for the currently installed RDataTracker Package.">
-    <echo>This batch of tests is quick to execute, but not as extensive.</echo>
-  </target>
-
-  <target name="long-test" depends="script-tests" description="Run long regression tests for the currently installed RDataTracker Package.">
-    <echo>This batch of tests takes longer, but is a bit more real-world</echo>
-  </target>
-
-  <!-- Target for tests run by people -->
-  <target name="test-all" depends="quick-test, long-test" description="Run all regression tests for the currently installed RDataTracker Package.">
-    <echo>All tests makes calls to the RDataTracker Library. You might need to restart RStudio to correctly run the scripts with the updated library installed. Output is saved in tests.log.</echo>
-  </target>
-
-  <!-- Target for tests run by Travis -->
-  <target name="test-travis" description="Runs all regression tests for the currently installed RDataTracker Package on Travis.">
-    <property name="using-travis" value="true"/>
-    <antcall target="quick-test"/>
-    <antcall target="long-test"/>
-    <echo>All tests makes calls to the RDataTracker Library. You might need to restart RStudio to correctly run the scripts with the updated library installed. Output is saved in tests.log.</echo>
-  </target>
-
-  <target name="install-and-test" description="Install the RDataTracker Package and perform all normal regression tests.">
-    <splash displaytext="Installing and Testing" />
-    <record name="tests.log" action="start" />
-      <antcall target="test-all" />
-    <record name="tests.log" action="stop" />
-  </target>
-
-  <!--################################# END MAIN #################################-->
-
-
-  <!--################################# UTILIES #################################-->
-
-  <!-- Test interactive() function when calling from command line -->
-  <target name="interactive-test">
-    <exec executable="Rscript" dir="tests" >
-      <arg line="RscriptTest.r" />
-    </exec>
-  </target>
-
-  <!-- Execute the script timer, which looks in the examples/ directory for all
-    files with a (-clear.r) suffix and a (template_)*(-annotated.r) pattern and
-    combined matching pairs to create a timing test. It executes a clean version of
-    the script, then minimally annotated the clean version and executes a console
-    and source version, and finally executes the annotated version.
-
-    This data is saved in the examples/_timingResults/ directory under the data/time
-    of execution.
-  -->
-  <target name="script-timer" depends="dependencies">
-    <splash displaytext="Running Performance Tests" />
-    <!-- Replace base.dir with the base directory of the project -->
-    <replaceregexp  file="utilities/scriptTimer.r"
-                    match="base.dir &lt;- (.*)"
-                    replace='base.dir &lt;- "${FILE.basedir}"'
-    />
-    <record name="script-timer.log" action="start" />
-      <exec executable="Rscript" dir="utilities">
-        <arg line="scriptTimer.r execute" />
-      </exec>
-    <record name="script-timer.log" action="stop" />
-  </target>
-
-  <!-- Executes the same as above, but logs a lot more information on each
-       script -->
-  <target name="script-timer-debug" depends="dependencies">
-    <replaceregexp  file="utilities/scriptTimer.r"
-                    match="base.dir &lt;- (.*)"
-                    replace='base.dir &lt;- "${FILE.basedir}"'
-    />
-    <record name="script-timer-debug.log" action="start" />
-      <exec executable="Rscript" dir="utilities">
-        <arg line="scriptTimer.r execute debug" />
-      </exec>
-    <record name="script-timer-debug.log" action="stop" />
-  </target>
-
-  <!-- Executes utilities/plot.r. Within this file, scriptTimer.r is executed (making the above
-       and unnecessary dependence).
-  -->
-  <target name="performance-report" depends="dependencies" description="Execute performance scripts on the current version of the library and generate a report.">
-    <splash displaytext="Creating Performance Report."/>
-    <!-- Replace base.dir with the base directory of the project -->
-    <replaceregexp  file="utilities/plot.r"
-                    match="base.dir &lt;- (.*)"
-                    replace='base.dir &lt;- "${FILE.basedir}"'
-    />
-    <record name="plot-performance.log" action="start" />
-      <exec executable="Rscript" dir="utilities">
-        <arg line="plot.r plot _plots" />
-      </exec>
-    <record name="plot-performance.log" action="stop" />
-  </target>
-
-  <!--################################# END UTILIES #################################-->
-  
-  
-  <!-- EF EDITS -->
-  <target name="prov-json-compliance-test">
-    <exec executable="Rscript" dir="tests/ProvJsonTest" resultproperty="compliant">
-      <arg value="ProvJsonTest.r" />
-      <arg path="tests/ProvJsonTest/schema.json" />
-      <arg path="${local_dir}/ddg.json.local" />
-    </exec>
-    <antcall target="prov-json-compliance-fail-check" />
-  </target>
-  
-  <target name="prov-json-compliance-fail-check" if="using-travis">
-    <fail message="ddg.json is not prov-json compliant.">
-      <condition>
-        <equals arg1="${compliant}" arg2="1"/>
-      </condition>
-    </fail>
-  </target>
-  
-  
 </project>

--- a/tests/ProvJsonTest/ProvJsonTest.r
+++ b/tests/ProvJsonTest/ProvJsonTest.r
@@ -1,9 +1,10 @@
-
 library(jsonvalidate)
 
-args <- commandArgs(TRUE)
+schema <- "schema.json"
 
-schema <- args[1]
-json <- args[2]
+# pass cases
+stopifnot( json_validate("cases/pass1.json", schema) )
+stopifnot( json_validate("cases/empty.json", schema) )
 
-print( json_validate(schema, json, verbose=TRUE) )
+# fail cases
+stopifnot( ! json_validate("cases/fail1.json", schema) )

--- a/tests/ProvJsonTest/ProvJsonTest.r
+++ b/tests/ProvJsonTest/ProvJsonTest.r
@@ -1,0 +1,9 @@
+
+library(jsonvalidate)
+
+args <- commandArgs(TRUE)
+
+schema <- args[1]
+json <- args[2]
+
+print( json_validate(schema, json, verbose=TRUE) )

--- a/tests/ProvJsonTest/cases/empty.json
+++ b/tests/ProvJsonTest/cases/empty.json
@@ -1,0 +1,100 @@
+{
+	"prefix": {
+		"prov": "http://www.w3.org/ns/prov#",
+		"rdt": "http://rdatatracker.org/"
+	},
+
+	"entity" : {
+		// environment
+		"environment": {
+			"rdt:name": "environment",
+			"rdt:architecture": "x86_64",
+			"rdt:operatingSystem": "windows",
+			"rdt:language": "R",
+			"rdt:rVersion": "R version 3.4.3 (2017-11-30)",
+			"rdt:script": "[DIR]/SourceFuncTest.R",
+			"rdt:scriptTimeStamp": "2018-01-11T06.29.26EST",
+			"rdt:sourcedScripts": "",
+			"rdt:sourcedScriptTimeStamps": "",
+			"rdt:workingDirectory": "[DIR]",
+			"rdt:ddgDirectory": "[DIR]/ddg",
+			"rdt:ddgTimeStamp": "2018-02-22T12.22.27EST",
+			"rdt:rdatatrackerVersion": "2.27.0",
+			"rdt:hashAlgorithm": "md5"
+		},
+
+		// library nodes - prov collections
+		"l1": {
+			"name": "base",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l2": {
+			"name": "datasets",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l3": {
+			"name": "graphics",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l4": {
+			"name": "grDevices",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l5": {
+			"name": "jsonlite",
+			"version": "1.5",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l6": {
+			"name": "methods",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l7": {
+			"name": "RDataTracker",
+			"version": "2.27.0",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l8": {
+			"name": "stats",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l9": {
+			"name": "utils",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		}
+	}
+}

--- a/tests/ProvJsonTest/cases/fail1.json
+++ b/tests/ProvJsonTest/cases/fail1.json
@@ -1,0 +1,278 @@
+{
+	"prefix": {
+		"prov": "http://www.w3.org/ns/prov#",
+		"rdt": "http://rdatatracker.org/"
+	},
+
+	"activity" : {
+		// procedure nodes
+		"p1": {
+			"rdt:name": "SourceFuncTest.R",
+			"rdt:type": "Start",
+			"rdt:elapsedTime": 0.25,
+			"rdt:scriptNum": "NA",
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"p2": {
+			"rdt:name": "fun <- function(a, b) {	return(a + b)}",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": 0.27,
+			"rdt:scriptNum": 0,
+			"rdt:startLine": 3,
+			"rdt:startCol": 1,
+			"rdt:endLine": 5,
+			"rdt:endCol": 1
+		},
+		"p3": {
+			"rdt:name": "x <- 6",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": 0.33,
+			"rdt:scriptNum": 0,
+			"rdt:startLine": 7,
+			"rdt:startCol": 1,
+			"rdt:endLine": 7,
+			"rdt:endCol": 6
+		}
+	},
+
+	"entity" : {
+		// data nodes
+		"d1": {
+			"rdt:name": "fun",
+			"rdt:value": "#ddg.function",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"character\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "R_GlobalEnv",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d2": {
+			"rdt:name": "x",
+			"rdt:value": "6",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "R_GlobalEnv",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d3": {
+			"rdt:name": "y",
+			"rdt:value": "10",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "R_GlobalEnv",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d4": {
+			"rdt:name": "a",
+			"rdt:value": "6",
+			"rdt:valType": {"container":"vector", "dimension":[1], "type":["numeric"]},
+			"rdt:type": "Data",
+			"rdt:scope": "0x0000000017664198",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+
+		// environment
+		"environment": {
+			"rdt:name": "environment",
+			"rdt:architecture": "x86_64",
+			"rdt:operatingSystem": "windows",
+			"rdt:language": "R",
+			"rdt:rVersion": "R version 3.4.3 (2017-11-30)",
+			"rdt:script": "[DIR]/SourceFuncTest.R",
+			"rdt:scriptTimeStamp": "2018-01-11T06.29.26EST",
+			"rdt:sourcedScripts": [
+				{
+					"number" : "1",
+					"name" : "source1.r",
+					"timestamp" : "2017-01-06T17.10.23EST"
+				},
+				{
+					"number" : "2",
+					"name" : "source2.r",
+					"timestamp" : "2017-01-06T17.10.23EST"
+				},
+				{
+					"number" : "3",
+					"name" : "source3.r",
+					"timestamp" : "2017-01-06T17.10.23EST"
+				},
+				{
+					"number" : "4",
+					"name" : "source4.r",
+					"timestamp" : "2017-01-06T17.10.22EST"
+				}
+			],
+			"rdt:sourcedScriptTimeStamps": [
+				"2018-01-11T06.29.26EST",
+				"2018-01-11T06.29.26EST",
+				"2018-01-11T06.29.26EST",
+				"2018-01-11T06.29.26EST"
+			],
+			"rdt:workingDirectory": "[DIR]",
+			"rdt:ddgDirectory": "[DIR]/ddg",
+			"rdt:ddgTimeStamp": "2018-02-22T12.22.27EST",
+			"rdt:rdatatrackerVersion": "2.27.0",
+			"rdt:hashAlgorithm": "md5"
+		},
+
+		// library nodes - prov collections
+		"l1": {
+			"name": "base",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l2": {
+			"name": "datasets",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l3": {
+			"name": "graphics",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l4": {
+			"name": "grDevices",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l5": {
+			"name": "jsonlite",
+			"version": "1.5",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l6": {
+			"name": "methods",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l7": {
+			"name": "RDataTracker",
+			"version": "2.27.0",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l8": {
+			"name": "stats",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l9": {
+			"name": "utils",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		}
+	},
+
+	"wasInformedBy" : {
+		// procedure-to-procedure edges
+		"pp1": {
+			"prov:informant": "rdt:p1",
+			"prov:informed": "rdt:p2"
+		},
+		"pp2": {
+			"prov:informant": "rdt:p2",
+			"prov:informed": "rdt:p3"
+		},
+		"pp3": {
+			"prov:informant": "rdt:p3",
+			"prov:informed": "rdt:p4"
+		},
+		"pp4": {
+			"prov:informant": "rdt:p4",
+			"prov:informed": "rdt:p5"
+		},
+		"pp5": {
+			"prov:informant": "rdt:p5",
+			"prov:informed": "rdt:p6"
+		}
+	},
+
+	"wasGeneratedBy" : {
+		// procedure-to-data edges
+		"pd1": {
+			"prov:activity": "rdt:p2",
+			"prov:entity": "rdt:d1"
+		},
+		"pd2": {
+			"prov:activity": "rdt:p3",
+			"prov:entity": "rdt:d2"
+		},
+		"pd3": {
+			"prov:activity": "rdt:p4",
+			"prov:entity": "rdt:d3"
+		},
+		"pd4": {
+			"prov:activity": "rdt:p7",
+			"prov:entity": "rdt:d4"
+		},
+		"pd5": {
+			"prov:activity": "rdt:p8",
+			"prov:entity": "rdt:d5"
+		},
+		"pd6": {
+			"prov:activity": "rdt:p10",
+			"prov:entity": "rdt:d6"
+		}
+	},
+
+	"used" : {
+		// data-to-procedure edges
+		"dp1": {
+			"prov:entity": "rdt:d1",
+			"prov:activity": "rdt:p5"
+		},
+		"dp2": {
+			"prov:entity": "rdt:d2",
+			"prov:activity": "p5"
+		},
+		"dp3": {
+			"prov:entity": "rdt:d3",
+			"prov:activity": "rdt:p5"
+		},
+		"dp4": {
+			"prov:entity": "rdt:d2",
+			"prov:activity": "rdt:p7"
+		}
+	}
+}

--- a/tests/ProvJsonTest/cases/pass1.json
+++ b/tests/ProvJsonTest/cases/pass1.json
@@ -1,0 +1,778 @@
+{
+	"prefix": {
+		"prov": "http://www.w3.org/ns/prov#",
+		"rdt": "http://rdatatracker.org/"
+	},
+
+	"activity" : {
+		// procedure nodes
+		"p1": {
+			"rdt:name": "SourceFuncTest.R",
+			"rdt:type": "Start",
+			"rdt:elapsedTime": 0.25,
+			"rdt:scriptNum": "NA",
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"p2": {
+			"rdt:name": "fun <- function(a, b) {	return(a + b)}",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": 0.27,
+			"rdt:scriptNum": 0,
+			"rdt:startLine": 3,
+			"rdt:startCol": 1,
+			"rdt:endLine": 5,
+			"rdt:endCol": 1
+		},
+		"p3": {
+			"rdt:name": "x <- 6",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": 0.33,
+			"rdt:scriptNum": 0,
+			"rdt:startLine": 7,
+			"rdt:startCol": 1,
+			"rdt:endLine": 7,
+			"rdt:endCol": 6
+		},
+		"p4": {
+			"rdt:name": "y <- 10",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": 0.5,
+			"rdt:scriptNum": 0,
+			"rdt:startLine": 8,
+			"rdt:startCol": 1,
+			"rdt:endLine": 8,
+			"rdt:endCol": 7
+		},
+		"p5": {
+			"rdt:name": "z <- fun(x, y)",
+			"rdt:type": "Start",
+			"rdt:elapsedTime": 0.5,
+			"rdt:scriptNum": 0,
+			"rdt:startLine": 9,
+			"rdt:startCol": 1,
+			"rdt:endLine": 9,
+			"rdt:endCol": 13
+		},
+		"p6": {
+			"rdt:name": "fun(x, y)",
+			"rdt:type": "Start",
+			"rdt:elapsedTime": 0.53,
+			"rdt:scriptNum": "NA",
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"p7": {
+			"rdt:name": "a  <-  x",
+			"rdt:type": "Binding",
+			"rdt:elapsedTime": 0.53,
+			"rdt:scriptNum": "NA",
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"p8": {
+			"rdt:name": "b  <-  y",
+			"rdt:type": "Binding",
+			"rdt:elapsedTime": 0.55,
+			"rdt:scriptNum": "NA",
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"p9": {
+			"rdt:name": "fun",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": 0.56,
+			"rdt:scriptNum": "NA",
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"p10": {
+			"rdt:name": "return(a + b)",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": 0.66,
+			"rdt:scriptNum": 0,
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"p11": {
+			"rdt:name": "fun(x, y)",
+			"rdt:type": "Finish",
+			"rdt:elapsedTime": 0.67,
+			"rdt:scriptNum": "NA",
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"p12": {
+			"rdt:name": "z <- fun(x, y)",
+			"rdt:type": "Finish",
+			"rdt:elapsedTime": 0.67,
+			"rdt:scriptNum": 0,
+			"rdt:startLine": 9,
+			"rdt:startCol": 1,
+			"rdt:endLine": 9,
+			"rdt:endCol": 13
+		},
+		"p13": {
+			"rdt:name": "source1.r",
+			"rdt:type": "Start",
+			"rdt:elapsedTime": 0.74,
+			"rdt:scriptNum": "NA",
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"p14": {
+			"rdt:name": "w <- z + x",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": 0.74,
+			"rdt:scriptNum": 1,
+			"rdt:startLine": 3,
+			"rdt:startCol": 1,
+			"rdt:endLine": 3,
+			"rdt:endCol": 10
+		},
+		"p15": {
+			"rdt:name": "w <- fun(w, y)",
+			"rdt:type": "Start",
+			"rdt:elapsedTime": 0.77,
+			"rdt:scriptNum": 1,
+			"rdt:startLine": 4,
+			"rdt:startCol": 1,
+			"rdt:endLine": 4,
+			"rdt:endCol": 13
+		},
+		"p16": {
+			"rdt:name": "fun(w, y)",
+			"rdt:type": "Start",
+			"rdt:elapsedTime": 0.8,
+			"rdt:scriptNum": "NA",
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"p17": {
+			"rdt:name": "a  <-  w",
+			"rdt:type": "Binding",
+			"rdt:elapsedTime": 0.8,
+			"rdt:scriptNum": "NA",
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"p18": {
+			"rdt:name": "b  <-  y",
+			"rdt:type": "Binding",
+			"rdt:elapsedTime": 0.81,
+			"rdt:scriptNum": "NA",
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"p19": {
+			"rdt:name": "fun",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": 0.81,
+			"rdt:scriptNum": "NA",
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		}
+	},
+
+	"entity" : {
+		// data nodes
+		"d1": {
+			"rdt:name": "fun",
+			"rdt:value": "#ddg.function",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"character\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "R_GlobalEnv",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d2": {
+			"rdt:name": "x",
+			"rdt:value": "6",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "R_GlobalEnv",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d3": {
+			"rdt:name": "y",
+			"rdt:value": "10",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "R_GlobalEnv",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d4": {
+			"rdt:name": "a",
+			"rdt:value": "6",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "0x0000000017664198",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d5": {
+			"rdt:name": "b",
+			"rdt:value": "10",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "0x0000000017664198",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d6": {
+			"rdt:name": "fun(x,y) return",
+			"rdt:value": "16",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "R_GlobalEnv",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d7": {
+			"rdt:name": "z",
+			"rdt:value": "16",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "R_GlobalEnv",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d8": {
+			"rdt:name": "w",
+			"rdt:value": "22",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "R_GlobalEnv",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d9": {
+			"rdt:name": "a",
+			"rdt:value": "22",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "0x000000001a494270",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d10": {
+			"rdt:name": "b",
+			"rdt:value": "10",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "0x000000001a494270",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d11": {
+			"rdt:name": "fun(w,y) return",
+			"rdt:value": "32",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "R_GlobalEnv",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d12": {
+			"rdt:name": "w",
+			"rdt:value": "32",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "R_GlobalEnv",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d13": {
+			"rdt:name": "z",
+			"rdt:value": "0",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "R_GlobalEnv",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d14": {
+			"rdt:name": "source1.r",
+			"rdt:value": "data/14-source1.r",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"character\"]}",
+			"rdt:type": "File",
+			"rdt:scope": "undefined",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "340bc12bb96a2c6e00559bca5882174b",
+			"rdt:timestamp": "2018-02-22T12.22.28EST",
+			"rdt:location": "[DIR]/source1.r"
+		},
+		"d15": {
+			"rdt:name": "a",
+			"rdt:value": "32",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "0x000000001782d510",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d16": {
+			"rdt:name": "b",
+			"rdt:value": "0",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "0x000000001782d510",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d17": {
+			"rdt:name": "fun(w,z) return",
+			"rdt:value": "32",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "R_GlobalEnv",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d18": {
+			"rdt:name": "v",
+			"rdt:value": "32",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "R_GlobalEnv",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d19": {
+			"rdt:name": "a",
+			"rdt:value": "10",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "R_GlobalEnv",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"d20": {
+			"rdt:name": "c",
+			"rdt:value": "100",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "R_GlobalEnv",
+			"rdt:fromEnv": false,
+			"rdt:MD5hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+
+		// environment
+		"environment": {
+			"rdt:name": "environment",
+			"rdt:architecture": "x86_64",
+			"rdt:operatingSystem": "windows",
+			"rdt:language": "R",
+			"rdt:rVersion": "R version 3.4.3 (2017-11-30)",
+			"rdt:script": "[DIR]/SourceFuncTest.R",
+			"rdt:scriptTimeStamp": "2018-01-11T06.29.26EST",
+			"rdt:sourcedScripts": [
+				"source1.r",
+				"source2.r",
+				"source3.r",
+				"source4.r"
+			],
+			"rdt:sourcedScriptTimeStamps": [
+				"2018-01-11T06.29.26EST",
+				"2018-01-11T06.29.26EST",
+				"2018-01-11T06.29.26EST",
+				"2018-01-11T06.29.26EST"
+			],
+			"rdt:workingDirectory": "[DIR]",
+			"rdt:ddgDirectory": "[DIR]/ddg",
+			"rdt:ddgTimeStamp": "2018-02-22T12.22.27EST",
+			"rdt:rdatatrackerVersion": "2.27.0",
+			"rdt:hashAlgorithm": "md5"
+		},
+
+		// library nodes - prov collections
+		"l1": {
+			"name": "base",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l2": {
+			"name": "datasets",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l3": {
+			"name": "graphics",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l4": {
+			"name": "grDevices",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l5": {
+			"name": "jsonlite",
+			"version": "1.5",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l6": {
+			"name": "methods",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l7": {
+			"name": "RDataTracker",
+			"version": "2.27.0",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l8": {
+			"name": "stats",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		},
+		"l9": {
+			"name": "utils",
+			"version": "3.4.3",
+			"prov:type": {
+				"$": "prov:Collection",
+				"type": "xsd:QName"
+			}
+		}
+	},
+
+	"wasInformedBy" : {
+		// procedure-to-procedure edges
+		"pp1": {
+			"prov:informant": "rdt:p1",
+			"prov:informed": "rdt:p2"
+		},
+		"pp2": {
+			"prov:informant": "rdt:p2",
+			"prov:informed": "rdt:p3"
+		},
+		"pp3": {
+			"prov:informant": "rdt:p3",
+			"prov:informed": "rdt:p4"
+		},
+		"pp4": {
+			"prov:informant": "rdt:p4",
+			"prov:informed": "rdt:p5"
+		},
+		"pp5": {
+			"prov:informant": "rdt:p5",
+			"prov:informed": "rdt:p6"
+		},
+		"pp6": {
+			"prov:informant": "rdt:p6",
+			"prov:informed": "rdt:p7"
+		},
+		"pp7": {
+			"prov:informant": "rdt:p7",
+			"prov:informed": "rdt:p8"
+		},
+		"pp8": {
+			"prov:informant": "rdt:p8",
+			"prov:informed": "rdt:p9"
+		},
+		"pp9": {
+			"prov:informant": "rdt:p9",
+			"prov:informed": "rdt:p10"
+		},
+		"pp10": {
+			"prov:informant": "rdt:p10",
+			"prov:informed": "rdt:p11"
+		},
+		"pp11": {
+			"prov:informant": "rdt:p11",
+			"prov:informed": "rdt:p12"
+		},
+		"pp12": {
+			"prov:informant": "rdt:p12",
+			"prov:informed": "rdt:p13"
+		},
+		"pp13": {
+			"prov:informant": "rdt:p13",
+			"prov:informed": "rdt:p14"
+		},
+		"pp14": {
+			"prov:informant": "rdt:p14",
+			"prov:informed": "rdt:p15"
+		},
+		"pp15": {
+			"prov:informant": "rdt:p15",
+			"prov:informed": "rdt:p16"
+		},
+		"pp16": {
+			"prov:informant": "rdt:p16",
+			"prov:informed": "rdt:p17"
+		},
+		"pp17": {
+			"prov:informant": "rdt:p17",
+			"prov:informed": "rdt:p18"
+		},
+		"pp18": {
+			"prov:informant": "rdt:p18",
+			"prov:informed": "rdt:p19"
+		},
+		"pp19": {
+			"prov:informant": "rdt:p19",
+			"prov:informed": "rdt:p20"
+		},
+		"pp20": {
+			"prov:informant": "rdt:p20",
+			"prov:informed": "rdt:p21"
+		}
+	},
+
+	"wasGeneratedBy" : {
+		// procedure-to-data edges
+		"pd1": {
+			"prov:activity": "rdt:p2",
+			"prov:entity": "rdt:d1"
+		},
+		"pd2": {
+			"prov:activity": "rdt:p3",
+			"prov:entity": "rdt:d2"
+		},
+		"pd3": {
+			"prov:activity": "rdt:p4",
+			"prov:entity": "rdt:d3"
+		},
+		"pd4": {
+			"prov:activity": "rdt:p7",
+			"prov:entity": "rdt:d4"
+		},
+		"pd5": {
+			"prov:activity": "rdt:p8",
+			"prov:entity": "rdt:d5"
+		},
+		"pd6": {
+			"prov:activity": "rdt:p10",
+			"prov:entity": "rdt:d6"
+		},
+		"pd7": {
+			"prov:activity": "rdt:p12",
+			"prov:entity": "rdt:d7"
+		},
+		"pd8": {
+			"prov:activity": "rdt:p14",
+			"prov:entity": "rdt:d8"
+		},
+		"pd9": {
+			"prov:activity": "rdt:p17",
+			"prov:entity": "rdt:d9"
+		},
+		"pd10": {
+			"prov:activity": "rdt:p18",
+			"prov:entity": "rdt:d10"
+		},
+		"pd11": {
+			"prov:activity": "rdt:p20",
+			"prov:entity": "rdt:d11"
+		},
+		"pd12": {
+			"prov:activity": "rdt:p22",
+			"prov:entity": "rdt:d12"
+		},
+		"pd13": {
+			"prov:activity": "rdt:p23",
+			"prov:entity": "rdt:d13"
+		},
+		"pd14": {
+			"prov:activity": "rdt:p28",
+			"prov:entity": "rdt:d15"
+		},
+		"pd15": {
+			"prov:activity": "rdt:p29",
+			"prov:entity": "rdt:d16"
+		},
+		"pd16": {
+			"prov:activity": "rdt:p31",
+			"prov:entity": "rdt:d17"
+		},
+		"pd17": {
+			"prov:activity": "rdt:p33",
+			"prov:entity": "rdt:d18"
+		},
+		"pd18": {
+			"prov:activity": "rdt:p35",
+			"prov:entity": "rdt:d19"
+		},
+		"pd19": {
+			"prov:activity": "rdt:p36",
+			"prov:entity": "rdt:d20"
+		},
+		"pd20": {
+			"prov:activity": "rdt:p37",
+			"prov:entity": "rdt:d21"
+		}
+	},
+
+	"used" : {
+		// data-to-procedure edges
+		"dp1": {
+			"prov:entity": "rdt:d1",
+			"prov:activity": "rdt:p5"
+		},
+		"dp2": {
+			"prov:entity": "rdt:d2",
+			"prov:activity": "rdt:p5"
+		},
+		"dp3": {
+			"prov:entity": "rdt:d3",
+			"prov:activity": "rdt:p5"
+		},
+		"dp4": {
+			"prov:entity": "rdt:d2",
+			"prov:activity": "rdt:p7"
+		},
+		"dp5": {
+			"prov:entity": "rdt:d3",
+			"prov:activity": "rdt:p8"
+		},
+		"dp6": {
+			"prov:entity": "rdt:d1",
+			"prov:activity": "rdt:p9"
+		},
+		"dp7": {
+			"prov:entity": "rdt:d4",
+			"prov:activity": "rdt:p9"
+		},
+		"dp8": {
+			"prov:entity": "rdt:d5",
+			"prov:activity": "rdt:p9"
+		},
+		"dp9": {
+			"prov:entity": "rdt:d4",
+			"prov:activity": "rdt:p10"
+		},
+		"dp10": {
+			"prov:entity": "rdt:d5",
+			"prov:activity": "rdt:p10"
+		},
+		"dp11": {
+			"prov:entity": "rdt:d6",
+			"prov:activity": "rdt:p12"
+		},
+		"dp12": {
+			"prov:entity": "rdt:d7",
+			"prov:activity": "rdt:p14"
+		},
+		"dp13": {
+			"prov:entity": "rdt:d2",
+			"prov:activity": "rdt:p14"
+		},
+		"dp14": {
+			"prov:entity": "rdt:d1",
+			"prov:activity": "rdt:p15"
+		},
+		"dp15": {
+			"prov:entity": "rdt:d8",
+			"prov:activity": "rdt:p15"
+		},
+		"dp16": {
+			"prov:entity": "rdt:d3",
+			"prov:activity": "rdt:p15"
+		},
+		"dp17": {
+			"prov:entity": "rdt:d8",
+			"prov:activity": "rdt:p17"
+		},
+		"dp18": {
+			"prov:entity": "rdt:d3",
+			"prov:activity": "rdt:p18"
+		},
+		"dp19": {
+			"prov:entity": "rdt:d1",
+			"prov:activity": "rdt:p19"
+		},
+		"dp20": {
+			"prov:entity": "rdt:d9",
+			"prov:activity": "rdt:p19"
+		}
+	}
+}

--- a/tests/ProvJsonTest/complianceTest.r
+++ b/tests/ProvJsonTest/complianceTest.r
@@ -1,0 +1,8 @@
+library(jsonvalidate)
+
+args <- commandArgs(TRUE)
+
+json <- args[1]
+schema <- args[2]
+
+print( json_validate(json, schema, verbose=TRUE) )

--- a/tests/ProvJsonTest/schema.json
+++ b/tests/ProvJsonTest/schema.json
@@ -1,0 +1,347 @@
+{
+    "id": "http://provenance.ecs.soton.ac.uk/prov-json/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Schema for a PROV-JSON document",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "prefix": {
+            "type": "object",
+            "patternProperties": {
+                        "^[a-zA-Z0-9_\\-]+$": { "type" : "string", "format": "uri" }
+            }
+        },
+        "entity": {
+            "type": "object",
+            "additionalProperties": { "$ref":"#/definitions/entity" }
+        },
+        "activity": {
+            "type": "object",
+            "additionalProperties": { "$ref":"#/definitions/activity" }
+        },
+        "agent": {
+            "type": "object",
+            "additionalProperties": { "$ref":"#/definitions/agent" }
+        },
+        "wasGeneratedBy": {
+            "type": "object",
+            "additionalProperties": { "$ref":"#/definitions/generation" }
+        },
+        "used": {
+            "type": "object",
+            "additionalProperties": { "$ref":"#/definitions/usage" }
+        },
+        "wasInformedBy": {
+            "type": "object",
+            "additionalProperties": { "$ref":"#/definitions/communication" }
+        },
+        "wasStartedBy": {
+            "type": "object",
+            "additionalProperties": { "$ref":"#/definitions/start" }
+        },
+        "wasEndedby": {
+            "type": "object",
+            "additionalProperties": { "$ref":"#/definitions/end" }
+        },
+        "wasInvalidatedBy": {
+            "type": "object",
+            "additionalProperties": { "$ref":"#/definitions/invalidation" }
+        },
+        "wasDerivedFrom": {
+            "type": "object",
+            "additionalProperties": { "$ref":"#/definitions/derivation" }
+        },
+        "wasAttributedTo": {
+            "type": "object",
+            "additionalProperties": { "$ref":"#/definitions/attribution" }
+        },
+        "wasAssociatedWith": {
+            "type": "object",
+            "additionalProperties": { "$ref":"#/definitions/association" }
+        },
+        "actedOnBehalfOf": {
+            "type": "object",
+            "additionalProperties": { "$ref":"#/definitions/delegation" }
+        },
+        "wasInfluencedBy": {
+            "type": "object",
+            "additionalProperties": { "$ref":"#/definitions/influence" }
+        },
+        "specializationOf": {
+            "type": "object",
+            "additionalProperties": { "$ref":"#/definitions/specialization" }
+        },
+        "alternateOf": {
+            "type": "object",
+            "additionalProperties": { "$ref":"#/definitions/alternate" }
+        },
+        "hadMember": {
+            "type": "object",
+            "additionalProperties": { "$ref":"#/definitions/membership" }
+        },
+        "bundle": {
+            "type": "object",
+            "additionalProperties": { "$ref":"#/definitions/bundle" }
+        }
+    },
+    "definitions": {
+        "typedLiteral": {
+            "title": "PROV-JSON Typed Literal",
+            "type": "object",
+            "properties": {
+                "$": { "type": "string" },
+                "type": { "type": "string", "format": "uri" },
+                "lang": { "type": "string" }
+            },
+            "required": ["$"],
+            "additionalProperties": false
+        },
+        "stringLiteral": {"type": "string"},
+        "numberLiteral": {"type": "number"},
+        "booleanLiteral": {"type": "boolean"},
+        "literalArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "anyOf": [
+                    { "$ref": "#/definitions/stringLiteral" },
+                    { "$ref": "#/definitions/numberLiteral" },
+                    { "$ref": "#/definitions/booleanLiteral" },
+                    { "$ref": "#/definitions/typedLiteral" }
+                ]
+            }
+        },
+        "attributeValues": {
+            "anyOf": [
+                { "$ref": "#/definitions/stringLiteral" },
+                { "$ref": "#/definitions/numberLiteral" },
+                { "$ref": "#/definitions/booleanLiteral" },
+                { "$ref": "#/definitions/typedLiteral" },
+                { "$ref": "#/definitions/literalArray" }
+            ]
+        },
+        "entity": {
+            "type": "object",
+            "title": "entity",
+            "additionalProperties": { "$ref": "#/definitions/attributeValues" }
+        },
+        "agent": { "$ref": "#/definitions/entity" },
+        "activity": {
+            "type": "object",
+            "title": "activity",
+            "prov:startTime": { "type": "string", "format": "date-time" },
+            "prov:endTime": { "type": "string", "format": "date-time" },
+            "additionalProperties": { "$ref": "#/definitions/attributeValues" }
+        },
+        "generation": {
+            "type": "object",
+            "title": "generation/usage",
+            "properties": {
+                "prov:entity": { "type": "string", "format": "uri" },
+                "prov:activity": { "type": "string", "format": "uri" },
+                "prov:time": { "type": "string", "format": "date-time" }
+            },
+            "required": ["prov:entity"],
+            "additionalProperties": { "$ref": "#/definitions/attributeValues" }
+        },
+        "usage": {"$ref":"#/definitions/generation"},
+        "communication":{
+            "type": "object",
+            "title": "communication",
+            "properties": {
+                "prov:informant": {"type": "string", "format": "uri"},
+                "prov:informed": {"type": "string", "format": "uri"}
+            },
+            "required": ["prov:informant", "prov:informed"],
+            "additionalProperties": { "$ref": "#/definitions/attributeValues" }
+        },
+        "start":{
+            "type": "object",
+            "title": "start/end",
+            "properties": {
+                "prov:activity": {"type": "string", "format": "uri"},
+                "prov:time": {"type": "string", "format": "date-time"},
+                "prov:trigger": {"type": "string", "format": "uri"}
+            },
+            "required": ["prov:activity"],
+            "additionalProperties": { "$ref": "#/definitions/attributeValues" }
+        },
+        "end": {"$ref":"#/definitions/start"},
+        "invalidation":{
+            "type": "object",
+            "title": "invalidation",
+            "properties": {
+                "prov:entity": { "type": "string", "format": "uri" },
+                "prov:time": { "type": "string", "format": "date-time" },
+                "prov:activity": { "type": "string", "format": "uri" }
+            },
+            "required": ["prov:entity"],
+            "additionalProperties": { "$ref": "#/definitions/attributeValues" }
+        },
+        "derivation":{
+            "type": "object",
+            "title": "derivation",
+            "properties": {
+                "prov:generatedEntity": { "type": "string", "format": "uri" },
+                "prov:usedEntity": { "type": "string", "format": "uri" },
+                "prov:activity": { "type": "string", "format": "uri" },
+                "prov:generation": { "type": "string", "format": "uri" },
+                "prov:usage": { "type": "string", "format": "uri" }
+            },
+            "required": ["prov:generatedEntity", "prov:usedEntity"],
+            "additionalProperties": { "$ref": "#/definitions/attributeValues" }
+        },
+        "attribution":{
+            "type": "object",
+            "title": "attribution",
+            "properties": {
+                "prov:entity": { "type": "string", "format": "uri" },
+                "prov:agent": { "type": "string", "format": "uri" }
+            },
+            "required": ["prov:entity", "prov:agent"],
+            "additionalProperties": { "$ref": "#/definitions/attributeValues" }
+        },
+        "association": {
+            "type": "object",
+            "title": "association",
+            "properties": {
+                "prov:activity": { "type": "string", "format": "uri" },
+                "prov:agent": { "type": "string", "format": "uri" },
+                "prov:plan": { "type": "string", "format": "uri" }
+            },
+            "required": ["prov:activity"],
+            "additionalProperties": { "$ref": "#/definitions/attributeValues" }
+        },
+        "delegation": {
+            "type": "object",
+            "title": "delegation",
+            "properties": {
+                "prov:delegate": { "type": "string", "format": "uri" },
+                "prov:responsible": { "type": "string", "format": "uri" },
+                "prov:activity": { "type": "string", "format": "uri" }
+            },
+            "required": ["prov:delegate", "prov:responsible"],
+            "additionalProperties": { "$ref": "#/definitions/attributeValues" }
+        },
+        "influence": {
+            "type": "object",
+            "title": "",
+            "properties": {
+                "prov:influencer": { "type": "string", "format": "uri" },
+                "prov:influencee": { "type": "string", "format": "uri" }
+            },
+            "required": ["prov:influencer", "prov:influencee"],
+            "additionalProperties": { "$ref": "#/definitions/attributeValues" }
+        },
+        "specialization": {
+            "type": "object",
+            "title": "specialization",
+            "properties": {
+                "prov:generalEntity": { "type": "string", "format": "uri" },
+                "prov:specificEntity": { "type": "string", "format": "uri" }
+            },
+            "required": ["prov:generalEntity", "prov:specificEntity"],
+            "additionalProperties": { "$ref": "#/definitions/attributeValues" }
+        },
+        "alternate": {
+            "type": "object",
+            "title": "alternate",
+            "properties": {
+                "prov:alternate1": { "type": "string", "format": "uri" },
+                "prov:alternate2": { "type": "string", "format": "uri" }
+            },
+            "required": ["prov:alternate1", "prov:alternate2"],
+            "additionalProperties": { "$ref": "#/definitions/attributeValues" }
+        },
+        "membership": {
+            "type": "object",
+            "title": "membership",
+            "properties": {
+                "prov:collection": { "type": "string", "format": "uri" },
+                "prov:entity": { "type": "string", "format": "uri" }
+            },
+            "required": ["prov:collection", "prov:entity"],
+            "additionalProperties": { "$ref": "#/definitions/attributeValues" }
+        },
+        "bundle": {
+            "type": "object",
+            "title": "bundle",
+            "properties":{
+                "prefix": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9_\\-]+$": { "type" : "string", "format": "uri" }
+                    }
+                },
+                "entity": {
+                    "type": "object",
+                    "additionalProperties": { "$ref":"#/definitions/entity" }
+                },
+                "activity": {
+                    "type": "object",
+                    "additionalProperties": { "$ref":"#/definitions/activity" }
+                },
+                "agent": {
+                    "type": "object",
+                    "additionalProperties": { "$ref":"#/definitions/agent" }
+                },
+                "wasGeneratedBy": {
+                    "type": "object",
+                    "additionalProperties": { "$ref":"#/definitions/generation" }
+                },
+                "used": {
+                    "type": "object",
+                    "additionalProperties": { "$ref":"#/definitions/usage" }
+                },
+                "wasInformedBy": {
+                    "type": "object",
+                    "additionalProperties": { "$ref":"#/definitions/communication" }
+                },
+                "wasStartedBy": {
+                    "type": "object",
+                    "additionalProperties": { "$ref":"#/definitions/start" }
+                },
+                "wasEndedby": {
+                    "type": "object",
+                    "additionalProperties": { "$ref":"#/definitions/end" }
+                },
+                "wasInvalidatedBy": {
+                    "type": "object",
+                    "additionalProperties": { "$ref":"#/definitions/invalidation" }
+                },
+                "wasDerivedFrom": {
+                    "type": "object",
+                    "additionalProperties": { "$ref":"#/definitions/derivation" }
+                },
+                "wasAttributedTo": {
+                    "type": "object",
+                    "additionalProperties": { "$ref":"#/definitions/attribution" }
+                },
+                "wasAssociatedWith": {
+                    "type": "object",
+                    "additionalProperties": { "$ref":"#/definitions/association" }
+                },
+                "actedOnBehalfOf": {
+                    "type": "object",
+                    "additionalProperties": { "$ref":"#/definitions/delegation" }
+                },
+                "wasInfluencedBy": {
+                    "type": "object",
+                    "additionalProperties": { "$ref":"#/definitions/influence" }
+                },
+                "specializationOf": {
+                    "type": "object",
+                    "additionalProperties": { "$ref":"#/definitions/specialization" }
+                },
+                "alternateOf": {
+                    "type": "object",
+                    "additionalProperties": { "$ref":"#/definitions/alternate" }
+                },
+                "hadMember": {
+                    "type": "object",
+                    "additionalProperties": { "$ref":"#/definitions/membership" }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Prov-Json compliance testing is run on each test before edits to the files are made before the diff check. This done in the target `prov-json-compliance-test`. 

Additionally, when the ant targets `test-all` and `test-travis` are run, the test, `ProvJsonTest`, will run before `basicTest`. This is a short test that runs the `json_validate` function of the package `jsonvalidate` on cases where it is and it is not compliant, to make sure that the results are as expected.

When using the target `test-travis`, the build will fail if the above tests fail.