### PR TITLE
Refactoring

### DIFF
--- a/R/Functions.R
+++ b/R/Functions.R
@@ -55,9 +55,14 @@
 }
 
 #' Add new functions to the function table
-#' @param pfunctions the rows to add
+#' @param pfunctions a data frame pairing functions with the libraries they come from
 #' @return nothing
 .ddg.add.to.function.table <- function (pfunctions) {
+  if( is.null(pfunctions) || is.na(pfunctions)) {
+    return()
+  } 
+    
+  pfunctions <- cbind( "ddg.pnum" = rep(.ddg.pnum(), nrow(pfunctions)) , pfunctions )
   ddg.function.nodes <- rbind( .ddg.function.nodes() , pfunctions )
   .ddg.set( "ddg.function.nodes" , ddg.function.nodes )
 }

--- a/R/ProcNodes.R
+++ b/R/ProcNodes.R
@@ -185,12 +185,11 @@
 #' @param pname the name for the node
 #' @param pvalue ???
 #' @param ptime elapsed time
-#' @param pfunctions functions called in the procedure 
 #' @param snum the number the script is in (main script = 0)
 #' @param pos the starting and ending line and column location of the statement
 #' 
 #' @return nothing
-.ddg.record.proc <- function(ptype, pname, pvalue, ptime, pfunctions=NULL, snum=NA, pos=NA) {
+.ddg.record.proc <- function(ptype, pname, pvalue, ptime, snum=NA, pos=NA) {
   if (!.ddg.is.proc.type (ptype)) {
     print (paste (".ddg.record.proc: bad value for ptype - ", ptype))
   }
@@ -228,13 +227,6 @@
   # Save the table
   .ddg.set("ddg.proc.nodes", ddg.proc.nodes)
   
-  # append to function call information to function nodes
-  if( ! (is.null(pfunctions) || is.na(pfunctions)) )
-  {
-    pfunctions <- cbind( "ddg.pnum" = rep(ddg.pnum, nrow(pfunctions)) , pfunctions )
-    .ddg.add.to.function.table (pfunctions)
-  }
-  
   if (.ddg.debug.lib()) {
     print (paste("Adding procedure node", ddg.pnum, "named", pname))
   }
@@ -245,10 +237,10 @@
 #' @param ptype type of procedure node.
 #' @param pname name of procedure node.
 #' @param pvalue (optional) value of procedure node.
-#' @param pfunctions functions called in the procedure
+#' @param functions.called vector of names of functions called in this procedure node
 #' @param console (optional) if TRUE, console mode is enabled.
 #' @param cmd the DDGStatement corresponding to this procedure node
-.ddg.proc.node <- function(ptype, pname, pvalue="", pfunctions=NULL, console=FALSE,
+.ddg.proc.node <- function(ptype, pname, pvalue="", functions.called=NULL, console=FALSE,
     cmd = NULL) {
 
   if (!.ddg.is.proc.type (ptype)) {
@@ -305,8 +297,13 @@
   ptime <- .ddg.elapsed.time()
   
   # Record in procedure node table
-  .ddg.record.proc(ptype, pname, pvalue, ptime, pfunctions, snum, pos)
+  .ddg.record.proc(ptype, pname, pvalue, ptime, snum, pos)
   
+  # append the function call information to function nodes
+  if( !is.null(functions.called) && !is.na(functions.called)) {
+    pfunctions <- .ddg.get.function.info(functions.called)
+    .ddg.add.to.function.table (pfunctions)
+  }
   if (.ddg.debug.lib()) print(paste("proc.node:", ptype, pname))
 }
 

--- a/R/RDataTracker.R
+++ b/R/RDataTracker.R
@@ -1037,11 +1037,11 @@ library(curl)
 
 .ddg.link.function.returns <- function(command) {
   
-  new.uses <- .ddg.get.matching.return.value.nodes (command)
+  return.value.nodes <- .ddg.get.matching.return.value.nodes (command)
   #print (paste (".ddg.link.function.returns: new.uses:", new.uses))
   
   # Create an edge from each of these to the last procedure node.
-  lapply (new.uses$return.node.id, function (data.num) {
+  lapply (return.value.nodes, function (data.num) {
         .ddg.datanum2lastproc (data.num)
   
         # Set the return value as being used.
@@ -1525,11 +1525,8 @@ library(curl)
             warning = .ddg.set.warning ,
             error = function(e)
             {
-              # obtain function information for error-causing operation
-              funcs.called <- .ddg.get.function.info(cmd@functions.called)
-              
               # create procedure node for the error-causing operation
-              .ddg.proc.node("Operation", cmd@abbrev, cmd@abbrev, pfunctions=funcs.called, console=TRUE, cmd=cmd)
+              .ddg.proc.node("Operation", cmd@abbrev, cmd@abbrev, functions.called=cmd@functions.called, console=TRUE, cmd=cmd)
               .ddg.proc2proc()
 
               # create input edges by adding variables to set
@@ -1598,14 +1595,11 @@ library(curl)
         # We want to create a procedure node for this command.
         if (create.procedure) {
           
-          # get function information
-          funcs.called <- .ddg.get.function.info(cmd@functions.called)
-          
           # Create the procedure node.
 
           if (.ddg.debug.lib()) print(paste(".ddg.parse.commands: Adding operation node for", cmd@abbrev))
           
-          .ddg.proc.node("Operation", cmd@abbrev, cmd@abbrev, pfunctions=funcs.called, console=TRUE, cmd=cmd)
+          .ddg.proc.node("Operation", cmd@abbrev, cmd@abbrev, functions.called=cmd@functions.called, console=TRUE, cmd=cmd)
           .ddg.proc2proc()
 
           # If a warning occurred when cmd was evaluated,

--- a/R/ReturnValues.R
+++ b/R/ReturnValues.R
@@ -100,14 +100,8 @@
   uses <- sapply(unused.calls, function(call) {grepl(call, command.text, fixed=TRUE)})
   #print (paste (".ddg.link.function.returns: uses:", uses))
   
-  # The following line is here to get around R CMD check, which
-  # otherwise reports:  no visible binding for global variable.
-  # Note that return.node.id is not a variable in the subset call,
-  # but the name of a column in the data frame being subsetted.
-  return.node.id <- NULL
-  
   # Extracts for the return value nodes.
-  return (subset(unused.returns, uses, return.node.id))
+  return (unused.returns[uses, ]$return.node.id)
 }
 
 #' Mark a return value as being used.


### PR DESCRIPTION
Changed return value type from .ddg.get.matching.return.value.nodes to
be a vector instead of a data frame.

Changed where .ddg.add.to.function.table is called to reduce the amount
of parameter passing required.