### PR TITLE
Express

### DIFF
--- a/R/API_core.R
+++ b/R/API_core.R
@@ -553,7 +553,7 @@
     # and evaluate commands without collecting provenance.
     else {
       if (is.na(calling.script)) .ddg.proc.node("Operation", sname)
-      .ddg.evaluate(exprs, environ=envir)
+      .ddg.evaluate.commands(exprs, environ=envir)
     }
   }
 

--- a/R/API_core.R
+++ b/R/API_core.R
@@ -522,7 +522,7 @@
     # Initialize the tables for ddg.capture.
     .ddg.set("from.source", TRUE)
 
-    # If ddg.details is True, parse and execute the commands, collecting provenance
+    # If ddg.details is True, execute the commands and collect provenance
     # along the way. If called from prov.run, there is no position information.
     # Otherwise, record script number and position in the start and finish nodes.
     if (.ddg.details()) {
@@ -550,7 +550,7 @@
     } 
 
     # If ddg.details is False, create a single procedural node for the main script
-    # and evaluate commands without collecting provenance.
+    # and evaluate commands without collecting provenance for each command.
     else {
       if (is.na(calling.script)) .ddg.proc.node("Operation", sname)
       .ddg.evaluate.commands(exprs, environ=envir)

--- a/R/API_core.R
+++ b/R/API_core.R
@@ -49,6 +49,9 @@
   # Get R script path
   r.script.path <- .ddg.r.script.path()
 
+  # Set ddg.details to True if in console mode.
+  if (!.ddg.script.mode()) .ddg.set("ddg.details", TRUE)
+
   # Set path for provenance graph
   .ddg.set.path (prov.dir, r.script.path, overwrite)
   

--- a/R/API_core.R
+++ b/R/API_core.R
@@ -522,29 +522,39 @@
     # Initialize the tables for ddg.capture.
     .ddg.set("from.source", TRUE)
 
-    # Parse and execute the commands, collecting provenance along the way.
-    # If called from prov.run, there is no position information.  Otherwise,
-    # record script number and posiiton in the start and finish nodes.
-    if (is.na(calling.script)) {
-      .ddg.add.start.node (node.name=sname)
-    }
-    else {
-      .ddg.add.start.node (node.name=paste0 ("source (\"", sname, "\")"), 
-                           script.num=calling.script,
-                           startLine=startLine, startCol=startCol, 
-                           endLine=endLine, endCol=endCol)
-    }
-    .ddg.parse.commands(exprs, sname, snum, environ=envir, ignore.patterns=ignores,
-      echo = echo, print.eval = print.eval, max.deparse.length = max.deparse.length,
-      run.commands = TRUE)
-    if (is.na(calling.script)) {
-      .ddg.add.finish.node ()
-    }
-    else {
-      .ddg.add.finish.node (script.num=calling.script,
-          startLine=startLine, startCol=startCol, endLine=endLine, endCol=endCol)
-    }
+    # If ddg.details is True, parse and execute the commands, collecting provenance
+    # along the way. If called from prov.run, there is no position information.
+    # Otherwise, record script number and position in the start and finish nodes.
+    if (.ddg.details()) {
+      if (is.na(calling.script)) {
+        .ddg.add.start.node (node.name=sname)
+      }
+      else {
+        .ddg.add.start.node (node.name=paste0 ("source (\"", sname, "\")"), 
+                            script.num=calling.script,
+                            startLine=startLine, startCol=startCol, 
+                            endLine=endLine, endCol=endCol)
+      }
+    
+      .ddg.parse.commands(exprs, sname, snum, environ=envir, ignore.patterns=ignores,
+        echo = echo, print.eval = print.eval, max.deparse.length = max.deparse.length,
+        run.commands = TRUE)
+    
+      if (is.na(calling.script)) {
+        .ddg.add.finish.node ()
+      }
+      else {
+        .ddg.add.finish.node (script.num=calling.script,
+        startLine=startLine, startCol=startCol, endLine=endLine, endCol=endCol)
+      }
+    } 
 
+    # If ddg.details is False, create a single procedural node for the main script
+    # and evaluate commands without collecting provenance.
+    else {
+      if (is.na(calling.script)) .ddg.proc.node("Operation", sname)
+      .ddg.evaluate(exprs, environ=envir)
+    }
   }
 
   invisible()

--- a/R/API_rdt.R
+++ b/R/API_rdt.R
@@ -66,8 +66,8 @@
 #' is used.
 #' @param overwrite if FALSE, includes a time stamp in the provenance
 #'   graph directory name.
-#' @param details if TRUE, provenance is collected for each top-level
-#' statement.
+#' @param details if FALSE, provenance is not collected for top-level
+#' statements in script mode.
 #' @param annotate.inside.functions if TRUE, provenance is collected 
 #' inside functions.
 #' @param first.loop the first loop to collect provenance in a for, 
@@ -112,8 +112,12 @@ prov.init <- function(prov.dir = NULL, overwrite = TRUE, details = TRUE,
   # Save name of provenance collection tool.
   .ddg.set("ddg.tool.name", "rdt")
 
-  # Save details value
-  .ddg.set("ddg.details", details)
+  # Save details value if in script mode. Otherwise set ddg.details to True.
+  if (.ddg.script.mode()) {
+    .ddg.set("ddg.details", details)
+  } else {
+    .ddg.set("ddg.details", TRUE)
+  }
 
   # Save hash algorithm
   .ddg.set("ddg.hash.algorithm", hash.algorithm)

--- a/R/API_rdt.R
+++ b/R/API_rdt.R
@@ -66,8 +66,6 @@
 #' is used.
 #' @param overwrite if FALSE, includes a time stamp in the provenance
 #'   graph directory name.
-#' @param details if FALSE, provenance is not collected for top-level
-#' statements in script mode.
 #' @param annotate.inside.functions if TRUE, provenance is collected 
 #' inside functions.
 #' @param first.loop the first loop to collect provenance in a for, 
@@ -99,9 +97,8 @@
 #'   \code{\link{prov.annotate.on}} and \code{\link{prov.annotate.off}} to see how to control
 #'     annotation of individual functions
 
-prov.init <- function(prov.dir = NULL, overwrite = TRUE, details = TRUE, 
-  annotate.inside.functions = FALSE, first.loop = 1, max.loops = 0, snapshot.size = 0, 
-  hash.algorithm = "md5", save.debug = FALSE) {
+prov.init <- function(prov.dir = NULL, overwrite = TRUE, annotate.inside.functions = FALSE, 
+  first.loop = 1, max.loops = 0, snapshot.size = 0, hash.algorithm = "md5", save.debug = FALSE) {
 
   if (.ddg.is.set("ddg.initialized") && .ddg.get ("ddg.initialized") == TRUE) {
     stop ("Provenance collection is already started.  
@@ -111,13 +108,6 @@ prov.init <- function(prov.dir = NULL, overwrite = TRUE, details = TRUE,
   
   # Save name of provenance collection tool.
   .ddg.set("ddg.tool.name", "rdt")
-
-  # Save details value if in script mode. Otherwise set ddg.details to True.
-  if (.ddg.script.mode()) {
-    .ddg.set("ddg.details", details)
-  } else {
-    .ddg.set("ddg.details", TRUE)
-  }
 
   # Save hash algorithm
   .ddg.set("ddg.hash.algorithm", hash.algorithm)
@@ -208,6 +198,8 @@ prov.quit <- function(save.debug = FALSE) {
 #' script with calls to prov.init and prov.quit.  
 #' @param r.script.path the full path to the R script file that is being 
 #' executed. A copy of the script will be saved with the provenance graph.
+#' @param details if FALSE, provenance is not collected for top-level
+#' statements.
 #' @param display if TRUE, the provenance graph is displayed in DDG Explorer
 #' @return prov.run runs a script, collecting provenance as it does so.  
 #'   It does not return a value. 
@@ -240,11 +232,14 @@ prov.run <- function(r.script.path, prov.dir = NULL, overwrite = TRUE, details =
   # Store R script path
   .ddg.set("ddg.r.script.path", r.script.path)
 
+  # Store details value
+  .ddg.set("ddg.details", details)
+
   # Set script mode to True
   .ddg.set("ddg.script.mode", TRUE)
 
   # Initialize the provenance graph
-  prov.init(prov.dir, overwrite, details, annotate.inside.functions, first.loop, max.loops, 
+  prov.init(prov.dir, overwrite, annotate.inside.functions, first.loop, max.loops, 
     snapshot.size, hash.algorithm, save.debug)
   
   # Execute the script

--- a/R/API_rdt.R
+++ b/R/API_rdt.R
@@ -66,6 +66,8 @@
 #' is used.
 #' @param overwrite if FALSE, includes a time stamp in the provenance
 #'   graph directory name.
+#' @param details if TRUE, provenance is collected for each top-level
+#' statement.
 #' @param annotate.inside.functions if TRUE, provenance is collected 
 #' inside functions.
 #' @param first.loop the first loop to collect provenance in a for, 
@@ -97,9 +99,9 @@
 #'   \code{\link{prov.annotate.on}} and \code{\link{prov.annotate.off}} to see how to control
 #'     annotation of individual functions
 
-prov.init <- function(prov.dir = NULL, overwrite = TRUE, annotate.inside.functions = 
-  FALSE, first.loop = 1, max.loops = 0, snapshot.size = 0, hash.algorithm = "md5",
-  save.debug = FALSE) {
+prov.init <- function(prov.dir = NULL, overwrite = TRUE, details = TRUE, 
+  annotate.inside.functions = FALSE, first.loop = 1, max.loops = 0, snapshot.size = 0, 
+  hash.algorithm = "md5", save.debug = FALSE) {
 
   if (.ddg.is.set("ddg.initialized") && .ddg.get ("ddg.initialized") == TRUE) {
     stop ("Provenance collection is already started.  
@@ -109,6 +111,9 @@ prov.init <- function(prov.dir = NULL, overwrite = TRUE, annotate.inside.functio
   
   # Save name of provenance collection tool.
   .ddg.set("ddg.tool.name", "rdt")
+
+  # Save details value
+  .ddg.set("ddg.details", details)
 
   # Save hash algorithm
   .ddg.set("ddg.hash.algorithm", hash.algorithm)
@@ -213,9 +218,9 @@ prov.quit <- function(save.debug = FALSE) {
 #' ab <- a + b
 #' prov.quit()
 
-prov.run <- function(r.script.path, prov.dir = NULL, overwrite = TRUE, 
-  annotate.inside.functions = FALSE, first.loop = 1, max.loops = 0,
-  snapshot.size = 0, hash.algorithm = "md5", save.debug = FALSE, display = FALSE) {
+prov.run <- function(r.script.path, prov.dir = NULL, overwrite = TRUE, details = TRUE, 
+  annotate.inside.functions = FALSE, first.loop = 1, max.loops = 0, snapshot.size = 0, 
+  hash.algorithm = "md5", save.debug = FALSE, display = FALSE) {
 
   # Stop & display message if R script path is missing
   if (missing(r.script.path)) {
@@ -235,7 +240,7 @@ prov.run <- function(r.script.path, prov.dir = NULL, overwrite = TRUE,
   .ddg.set("ddg.script.mode", TRUE)
 
   # Initialize the provenance graph
-  prov.init(prov.dir, overwrite, annotate.inside.functions, first.loop, max.loops, 
+  prov.init(prov.dir, overwrite, details, annotate.inside.functions, first.loop, max.loops, 
     snapshot.size, hash.algorithm, save.debug)
   
   # Execute the script

--- a/R/API_rdtLite.R
+++ b/R/API_rdtLite.R
@@ -58,8 +58,8 @@
 #' is used.
 #' @param overwrite if FALSE, includes a time stamp in the provenance
 #' graph directory name.
-#' @param details if TRUE, provenance is collected for each top-level
-#' statement.
+#' @param details if FALSE, provenance is not collected for top-level
+#' statements in script mode.
 #' @param snapshot.size the maximum size for snapshot files. If 0,
 #' no snapshots are saved. If Inf, the complete state of an object is stored
 #' in the snapshot file. For other values, the head of the object, truncated
@@ -88,8 +88,12 @@ prov.init <- function(prov.dir = NULL, overwrite = TRUE, details = TRUE, snapsho
   # Save name of provenance collection tool
   .ddg.set("ddg.tool.name", "rdtLite")
 
-  # Save details value
-  .ddg.set("ddg.details", details)
+  # Save details value if in script mode. Otherwise set ddg.details to True.
+  if (.ddg.script.mode()) {
+    .ddg.set("ddg.details", details)
+  } else {
+    .ddg.set("ddg.details", TRUE)
+  }
 
   # Save maximum snapshot size
   .ddg.set("ddg.snapshot.size", snapshot.size)

--- a/R/API_rdtLite.R
+++ b/R/API_rdtLite.R
@@ -58,8 +58,6 @@
 #' is used.
 #' @param overwrite if FALSE, includes a time stamp in the provenance
 #' graph directory name.
-#' @param details if FALSE, provenance is not collected for top-level
-#' statements in script mode.
 #' @param snapshot.size the maximum size for snapshot files. If 0,
 #' no snapshots are saved. If Inf, the complete state of an object is stored
 #' in the snapshot file. For other values, the head of the object, truncated
@@ -76,7 +74,7 @@
 #' @rdname prov.run
 #' @seealso \code{\link{prov.json}} for access to the JSON text of the provenance, 
 
-prov.init <- function(prov.dir = NULL, overwrite = TRUE, details = TRUE, snapshot.size = 0, 
+prov.init <- function(prov.dir = NULL, overwrite = TRUE, snapshot.size = 0, 
   hash.algorithm = "md5", save.debug = FALSE) {
   
   if (.ddg.is.set("ddg.initialized") && .ddg.get ("ddg.initialized") == TRUE) {
@@ -87,13 +85,6 @@ prov.init <- function(prov.dir = NULL, overwrite = TRUE, details = TRUE, snapsho
 
   # Save name of provenance collection tool
   .ddg.set("ddg.tool.name", "rdtLite")
-
-  # Save details value if in script mode. Otherwise set ddg.details to True.
-  if (.ddg.script.mode()) {
-    .ddg.set("ddg.details", details)
-  } else {
-    .ddg.set("ddg.details", TRUE)
-  }
 
   # Save maximum snapshot size
   .ddg.set("ddg.snapshot.size", snapshot.size)
@@ -148,6 +139,8 @@ prov.quit <- function(save.debug = FALSE) {
 #' script with calls to prov.init and prov.quit.  
 #' @param r.script.path the full path to the R script file that is being 
 #' executed. A copy of the script will be saved with the provenance graph.
+#' @param details if FALSE, provenance is not collected for top-level
+#' statements.
 #' @return prov.run runs a script, collecting provenance as it does so.  
 #'   It does not return a value. 
 #' @export
@@ -179,11 +172,14 @@ prov.run <- function(r.script.path, prov.dir = NULL, overwrite = TRUE, details =
   # Store R script path
   .ddg.set("ddg.r.script.path", r.script.path)
 
-  # Set script mode to True.
+  # Store details value
+  .ddg.set("ddg.details", details)
+
+  # Set script mode to True
   .ddg.set("ddg.script.mode", TRUE)
 
   # Intialize the provenance graph
-  prov.init(prov.dir, overwrite, details, snapshot.size, hash.algorithm, save.debug)
+  prov.init(prov.dir, overwrite, snapshot.size, hash.algorithm, save.debug)
   
   # Execute the script
   .ddg.run(r.script.path)

--- a/R/API_rdtLite.R
+++ b/R/API_rdtLite.R
@@ -58,6 +58,8 @@
 #' is used.
 #' @param overwrite if FALSE, includes a time stamp in the provenance
 #' graph directory name.
+#' @param details if TRUE, provenance is collected for each top-level
+#' statement.
 #' @param snapshot.size the maximum size for snapshot files. If 0,
 #' no snapshots are saved. If Inf, the complete state of an object is stored
 #' in the snapshot file. For other values, the head of the object, truncated
@@ -74,7 +76,7 @@
 #' @rdname prov.run
 #' @seealso \code{\link{prov.json}} for access to the JSON text of the provenance, 
 
-prov.init <- function(prov.dir = NULL, overwrite = TRUE, snapshot.size = 0, 
+prov.init <- function(prov.dir = NULL, overwrite = TRUE, details = TRUE, snapshot.size = 0, 
   hash.algorithm = "md5", save.debug = FALSE) {
   
   if (.ddg.is.set("ddg.initialized") && .ddg.get ("ddg.initialized") == TRUE) {
@@ -83,8 +85,11 @@ prov.init <- function(prov.dir = NULL, overwrite = TRUE, snapshot.size = 0,
     return()
   }
 
-# Save name of provenance collection tool
+  # Save name of provenance collection tool
   .ddg.set("ddg.tool.name", "rdtLite")
+
+  # Save details value
+  .ddg.set("ddg.details", details)
 
   # Save maximum snapshot size
   .ddg.set("ddg.snapshot.size", snapshot.size)
@@ -153,7 +158,7 @@ prov.quit <- function(save.debug = FALSE) {
 #' ab <- a + b
 #' prov.quit()
 
-prov.run <- function(r.script.path, prov.dir = NULL, overwrite = TRUE, 
+prov.run <- function(r.script.path, prov.dir = NULL, overwrite = TRUE, details = TRUE, 
   snapshot.size = 0, hash.algorithm = "md5", save.debug = FALSE) {
   
   # Stop & display message if R script path is missing
@@ -174,7 +179,7 @@ prov.run <- function(r.script.path, prov.dir = NULL, overwrite = TRUE,
   .ddg.set("ddg.script.mode", TRUE)
 
   # Intialize the provenance graph
-  prov.init(prov.dir, overwrite, snapshot.size, hash.algorithm, save.debug)
+  prov.init(prov.dir, overwrite, details, snapshot.size, hash.algorithm, save.debug)
   
   # Execute the script
   .ddg.run(r.script.path)

--- a/R/IOTrace.R
+++ b/R/IOTrace.R
@@ -412,6 +412,7 @@
   .ddg.add.infiles (files.read)
   
   for (file in files.read) {
+    # print (paste ("file read: ", file))
     # Use URL node for URLs and for socket connections
     if (grepl ("://", file) || startsWith (file, "->"))
     {
@@ -617,7 +618,7 @@
   files.written <- .ddg.get ("output.files")
   
   for (file in files.written) {
-    #print (paste ("file written: ", file))
+    # print (paste ("file written: ", file))
     if (.ddg.is.connection(file)) {
       conn <- as.numeric(file)
       # If it is a closed connection, use the file it is connected to
@@ -1127,11 +1128,15 @@
   # Add the newly-opened graphics device to the list of open devices
   .ddg.set("ddg.open.devices", union(.ddg.get("ddg.open.devices"), grDevices::dev.cur()))
 
-  # Create a node for the grpahics device and connect it to the last procedural node.
-  dev.node.name <- paste0("dev.", grDevices::dev.cur())
-  .ddg.device.node(dev.node.name)
-  .ddg.lastproc2data(dev.node.name)
-  
+  # Create a node for the graphics device and connect it to the last procedural node.
+    dev.node.name <- paste0("dev.", grDevices::dev.cur())
+
+    # Create graphics device node and edge if ddg.details is True.
+    if (.ddg.details()) {
+      .ddg.device.node(dev.node.name)
+      .ddg.lastproc2data(dev.node.name)
+    }
+
   # Remember that the device node was created for this statement to avoid duplicates.
   .ddg.set ("ddg.add.device.output", FALSE)
   .ddg.add.device.node (dev.node.name)
@@ -1174,14 +1179,18 @@
     
     # Check if there is already a node for this device. 
     if (grDevices::dev.cur() %in% .ddg.get("ddg.open.devices")) {
-      # Create an input edge from that node to the last procedure node
-      .ddg.data2proc(dev.node.name, dscope = NULL)
 
-      # Add an output node with the same name and make it an output from
-      # the last procedure node.
-      .ddg.device.node(dev.node.name)
-      .ddg.lastproc2data(dev.node.name)
-      
+      # Create graphics device node and edges if ddg.details is True
+      if (.ddg.details()) {
+        # Create an input edge from that node to the last procedure node
+        .ddg.data2proc(dev.node.name, dscope = NULL)
+
+        # Add an output node with the same name and make it an output from
+        # the last procedure node.
+        .ddg.device.node(dev.node.name)
+        .ddg.lastproc2data(dev.node.name)
+      }
+
       # Remember that the node was created.
       .ddg.add.device.node (dev.node.name)
     }
@@ -1292,6 +1301,7 @@
   
   # If going to a file, copy the file and create a node for it.
   if (!is.null (graphics.file)) {
+    # print (paste ("graphics file: ", graphics.file))
     .ddg.file.out (graphics.file)
     
     # Delete files that were created by capturing the screen

--- a/R/RDataTracker_core.R
+++ b/R/RDataTracker_core.R
@@ -1161,19 +1161,19 @@
   #}
 }
 
-#' .ddg.evaluate evaluates a list of parsed R statements. Provenance is collected
-#' for inputs and outputs only.
+#' .ddg.evaluate.commands evaluates a list of parsed R statements. Provenance is 
+#' collected for inputs and outputs only.
 
 #' @param exprs list of parsed R statements
 #' @noRd
 
-.ddg.evaluate <- function (exprs, environ) {
+.ddg.evaluate.commands <- function (exprs, environ) {
   for (expr in exprs) {
     eval(expr, environ, NULL)
     .ddg.create.file.read.nodes.and.edges ()
     .ddg.create.file.write.nodes.and.edges ()
     .ddg.create.graphics.nodes.and.edges ()
- }
+  }
 }
 
 #' .ddg.push.cmd pushes a command onto the command stack.  The command stack 

--- a/R/RDataTracker_core.R
+++ b/R/RDataTracker_core.R
@@ -1167,6 +1167,8 @@
 #' the error or warning message.
 
 #' @param exprs list of parsed R statements
+#' @param environ environment in which commands should be executed.
+#' @return nothing
 #' @noRd
 
 .ddg.evaluate.commands <- function (exprs, environ) {

--- a/R/RDataTracker_core.R
+++ b/R/RDataTracker_core.R
@@ -1161,6 +1161,21 @@
   #}
 }
 
+#' .ddg.evaluate evaluates a list of parsed R statements. Provenance is collected
+#' for inputs and outputs only.
+
+#' @param exprs list of parsed R statements
+#' @noRd
+
+.ddg.evaluate <- function (exprs, environ) {
+  for (expr in exprs) {
+    eval(expr, environ, NULL)
+    .ddg.create.file.read.nodes.and.edges ()
+    .ddg.create.file.write.nodes.and.edges ()
+    .ddg.create.graphics.nodes.and.edges ()
+ }
+}
+
 #' .ddg.push.cmd pushes a command onto the command stack.  The command stack 
 #' remembers the command about to be executed.  It also puts FALSE on the stack 
 #' to indicate that no start node has (yet) been created for the command.

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -145,7 +145,7 @@
   return(paste(.ddg.path(), "/scripts", sep=""))
 }
 
-#' .ddg.details returns True if collecting provenance for top-level statments
+#' .ddg.details returns True if collecting provenance for top-level statements
 #' @return True if collecting top-level provenance
 #' @noRd
 

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -145,6 +145,19 @@
   return(paste(.ddg.path(), "/scripts", sep=""))
 }
 
+#' .ddg.details returns True if collecting provenance for top-level statments
+#' @return True if collecting top-level provenance
+#' @noRd
+
+.ddg.details <- function() {
+  # Set to TRUE if not set
+  if (!.ddg.is.set("ddg.details")) {
+    .ddg.set("ddg.details", TRUE)
+  }
+
+  return(.ddg.get("ddg.details"))
+}
+
 ##### Mutators for specific common actions
 
 #' .ddg.inc increments a ddg counter

--- a/man_rdt/prov.run.Rd
+++ b/man_rdt/prov.run.Rd
@@ -32,8 +32,8 @@ is used.}
 \item{overwrite}{if FALSE, includes a time stamp in the provenance
 graph directory name.}
 
-\item{details}{if TRUE, provenance is collected for each top-level
-statement.}
+\item{details}{if FALSE, provenance is not collected for top-level
+statements in script mode.}
 
 \item{annotate.inside.functions}{if TRUE, provenance is collected 
 inside functions.}

--- a/man_rdt/prov.run.Rd
+++ b/man_rdt/prov.run.Rd
@@ -8,7 +8,7 @@
 \alias{prov.source}
 \title{Provenance Collection Functions}
 \usage{
-prov.init(prov.dir = NULL, overwrite = TRUE, details = TRUE,
+prov.init(prov.dir = NULL, overwrite = TRUE,
   annotate.inside.functions = FALSE, first.loop = 1, max.loops = 0,
   snapshot.size = 0, hash.algorithm = "md5", save.debug = FALSE)
 
@@ -31,9 +31,6 @@ is used.}
 
 \item{overwrite}{if FALSE, includes a time stamp in the provenance
 graph directory name.}
-
-\item{details}{if FALSE, provenance is not collected for top-level
-statements in script mode.}
 
 \item{annotate.inside.functions}{if TRUE, provenance is collected 
 inside functions.}
@@ -63,6 +60,9 @@ This is intended for developers of the rdt / rdtLite package.}
 
 \item{r.script.path}{the full path to the R script file that is being 
 executed. A copy of the script will be saved with the provenance graph.}
+
+\item{details}{if FALSE, provenance is not collected for top-level
+statements.}
 
 \item{display}{if TRUE, the provenance graph is displayed in DDG Explorer}
 

--- a/man_rdt/prov.run.Rd
+++ b/man_rdt/prov.run.Rd
@@ -8,7 +8,7 @@
 \alias{prov.source}
 \title{Provenance Collection Functions}
 \usage{
-prov.init(prov.dir = NULL, overwrite = TRUE,
+prov.init(prov.dir = NULL, overwrite = TRUE, details = TRUE,
   annotate.inside.functions = FALSE, first.loop = 1, max.loops = 0,
   snapshot.size = 0, hash.algorithm = "md5", save.debug = FALSE)
 
@@ -17,9 +17,9 @@ prov.save(save.debug = FALSE)
 prov.quit(save.debug = FALSE)
 
 prov.run(r.script.path, prov.dir = NULL, overwrite = TRUE,
-  annotate.inside.functions = FALSE, first.loop = 1, max.loops = 0,
-  snapshot.size = 0, hash.algorithm = "md5", save.debug = FALSE,
-  display = FALSE)
+  details = TRUE, annotate.inside.functions = FALSE, first.loop = 1,
+  max.loops = 0, snapshot.size = 0, hash.algorithm = "md5",
+  save.debug = FALSE, display = FALSE)
 
 prov.source(file)
 }
@@ -31,6 +31,9 @@ is used.}
 
 \item{overwrite}{if FALSE, includes a time stamp in the provenance
 graph directory name.}
+
+\item{details}{if TRUE, provenance is collected for each top-level
+statement.}
 
 \item{annotate.inside.functions}{if TRUE, provenance is collected 
 inside functions.}

--- a/man_rdtLite/prov.run.Rd
+++ b/man_rdtLite/prov.run.Rd
@@ -8,15 +8,16 @@
 \alias{prov.source}
 \title{Provenance Collection Functions}
 \usage{
-prov.init(prov.dir = NULL, overwrite = TRUE, snapshot.size = 0,
-  hash.algorithm = "md5", save.debug = FALSE)
+prov.init(prov.dir = NULL, overwrite = TRUE, details = TRUE,
+  snapshot.size = 0, hash.algorithm = "md5", save.debug = FALSE)
 
 prov.save(save.debug = FALSE)
 
 prov.quit(save.debug = FALSE)
 
 prov.run(r.script.path, prov.dir = NULL, overwrite = TRUE,
-  snapshot.size = 0, hash.algorithm = "md5", save.debug = FALSE)
+  details = TRUE, snapshot.size = 0, hash.algorithm = "md5",
+  save.debug = FALSE)
 
 prov.source(file)
 }
@@ -28,6 +29,9 @@ is used.}
 
 \item{overwrite}{if FALSE, includes a time stamp in the provenance
 graph directory name.}
+
+\item{details}{if TRUE, provenance is collected for each top-level
+statement.}
 
 \item{snapshot.size}{the maximum size for snapshot files. If 0,
 no snapshots are saved. If Inf, the complete state of an object is stored

--- a/man_rdtLite/prov.run.Rd
+++ b/man_rdtLite/prov.run.Rd
@@ -8,8 +8,8 @@
 \alias{prov.source}
 \title{Provenance Collection Functions}
 \usage{
-prov.init(prov.dir = NULL, overwrite = TRUE, details = TRUE,
-  snapshot.size = 0, hash.algorithm = "md5", save.debug = FALSE)
+prov.init(prov.dir = NULL, overwrite = TRUE, snapshot.size = 0,
+  hash.algorithm = "md5", save.debug = FALSE)
 
 prov.save(save.debug = FALSE)
 
@@ -30,9 +30,6 @@ is used.}
 \item{overwrite}{if FALSE, includes a time stamp in the provenance
 graph directory name.}
 
-\item{details}{if FALSE, provenance is not collected for top-level
-statements in script mode.}
-
 \item{snapshot.size}{the maximum size for snapshot files. If 0,
 no snapshots are saved. If Inf, the complete state of an object is stored
 in the snapshot file. For other values, the head of the object, truncated
@@ -48,6 +45,9 @@ This is intended for developers of the rdt / rdtLite package.}
 
 \item{r.script.path}{the full path to the R script file that is being 
 executed. A copy of the script will be saved with the provenance graph.}
+
+\item{details}{if FALSE, provenance is not collected for top-level
+statements.}
 
 \item{file}{the name of the R script file to source.}
 }

--- a/man_rdtLite/prov.run.Rd
+++ b/man_rdtLite/prov.run.Rd
@@ -30,8 +30,8 @@ is used.}
 \item{overwrite}{if FALSE, includes a time stamp in the provenance
 graph directory name.}
 
-\item{details}{if TRUE, provenance is collected for each top-level
-statement.}
+\item{details}{if FALSE, provenance is not collected for top-level
+statements in script mode.}
 
 \item{snapshot.size}{the maximum size for snapshot files. If 0,
 no snapshots are saved. If Inf, the complete state of an object is stored


### PR DESCRIPTION
A new parameter (details=TRUE) is added to prov.run in rdt / rdtLite.  If details=FALSE, provenance is collected for the computing environment, inputs & outputs, and errors & warnings, but not for individual statements.  This reduced level of functionality provides better performance and more closely matches what other provenance collection tools currently do.
