### PR TITLE
Cleaned up is.null and is.na calls.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@
 ^provR.Rcheck$
 ^provR*.tar.gz$
 tests.xml
+^.commit$

--- a/.travis-rdt.yml
+++ b/.travis-rdt.yml
@@ -20,8 +20,7 @@ before-install:
   - .libPaths ("/home/travis/R/Library")
 
 install: 
-  - Rscript -e 'install.packages (c("devtools", "roxygen2", "knitr", "jsonvalidate", "XML", "testthat", "gplots", "ggplot2", "stringi", "RCurl"))'
-  - Rscript -e 'if(!"provViz" %in% rownames(installed.packages())) { devtools::install_github("End-to-end-provenance/provViz") }'
+  - Rscript -e 'install.packages (c("devtools", "roxygen2", "knitr", "jsonvalidate", "XML", "testthat", "gplots", "ggplot2", "stringi", "RCurl", "provSummarizeR", "provViz"))'
   - Rscript -e 'print (installed.packages())'
 
 before_script:

--- a/.travis-rdtLite.yml
+++ b/.travis-rdtLite.yml
@@ -20,7 +20,7 @@ before-install:
   - .libPaths ("/home/travis/R/Library")
 
 install: 
-  - Rscript -e 'install.packages (c("devtools", "roxygen2", "knitr", "jsonvalidate", "XML", "testthat", "gplots", "ggplot2", "stringi", "RCurl"))'
+  - Rscript -e 'install.packages (c("devtools", "roxygen2", "knitr", "jsonvalidate", "XML", "testthat", "gplots", "ggplot2", "stringi", "RCurl", "provSummarizeR", "provViz"))'
   - Rscript -e 'print (installed.packages())'
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,7 @@ before-install:
   - .libPaths ("/home/travis/R/Library")
 
 install: 
-  - Rscript -e 'install.packages (c("devtools", "roxygen2", "knitr", "jsonvalidate", "XML", "testthat", "gplots", "ggplot2", "stringi", "RCurl"))'
-  - Rscript -e 'if(!"provViz" %in% rownames(installed.packages())) { devtools::install_github("End-to-end-provenance/provViz") }'
+  - Rscript -e 'install.packages (c("devtools", "roxygen2", "knitr", "jsonvalidate", "XML", "testthat", "gplots", "ggplot2", "stringi", "RCurl", "provSummarizeR", "provViz"))'
   - Rscript -e 'print (installed.packages())'
 
 before_script:

--- a/R/Functions.R
+++ b/R/Functions.R
@@ -65,8 +65,11 @@
 #' @noRd
 
 .ddg.add.to.function.table <- function (pfunctions) {
+  if ( .ddg.is.null.or.na (pfunctions)) {
+    return()
+  }
   
-  if( is.null(pfunctions) || is.na(pfunctions) || nrow(pfunctions) == 0) {
+  if( nrow(pfunctions) == 0 ) {
     return()
   } 
   

--- a/R/FunctionsDefined.R
+++ b/R/FunctionsDefined.R
@@ -110,7 +110,7 @@
 #'    a call to a function
 #' @noRd
 .ddg.get.nonlocals.set <- function (pfunctions) {
-  if( is.null(pfunctions) || is.na(pfunctions) || nrow(pfunctions) == 0) {
+  if (.ddg.is.null.or.na (pfunctions) || nrow(pfunctions) == 0) {
     return(vector())
   } 
   
@@ -204,7 +204,11 @@
 #'    a call to a function
 #' @noRd
 .ddg.get.nonlocals.used <- function (pfunctions) {
-  if( is.null(pfunctions) || is.na(pfunctions) || nrow(pfunctions) == 0) {
+  if (.ddg.is.null.or.na (pfunctions)) {
+    return ()
+  }
+
+  else if( nrow(pfunctions) == 0) {
     return()
   } 
   

--- a/R/ProcNodes.R
+++ b/R/ProcNodes.R
@@ -348,7 +348,7 @@
   .ddg.record.proc(ptype, pname, pvalue, ptime, snum, pos)
   
   # If any functions are called in this procedure node, process them.
-  if( !is.null(functions.called) && !is.na(functions.called)) {
+  if( !.ddg.is.null.or.na (functions.called)) {
     pfunctions <- .ddg.get.function.info(functions.called)
 
     # append the function call information to function nodes

--- a/R/Utilities.R
+++ b/R/Utilities.R
@@ -281,3 +281,39 @@
   installed <- data.frame (package, version)
   return(installed)
 }
+
+#' .ddg.is.null returns true if the variable itself is null.  is.null is a
+#' vectorized function.  This is a non-vectorized version.
+#' @return a single TRUE or FALSE value indicating if the variable is null.
+#' @noRd
+.ddg.is.null <- function (var) {
+  if (length(var) == 0) {
+    if (is.null(var)) {
+      return (TRUE)
+    }  
+  }
+  return (FALSE)
+}
+
+#' .ddg.is.na returns true if the variable itself is NA.  is.na is a vectorized
+#' function.  This is a non-vectorized version of it.
+#' @return a single TRUE or FALSE value indicating if the variable is NA.
+#' @noRd
+.ddg.is.na <- function (var) {
+  if (length(var) == 1) {
+    if (is.na(var)) {
+      return (TRUE)
+    }  
+  }
+  return (FALSE)
+}
+
+
+#' .ddg.is.null.or.na returns true if the variable itself is null or NA.
+#' @return a single TRUE or FALSE value indicating if the variable is null or NA.
+#' @noRd
+.ddg.is.null.or.na <- function (var) {
+  if (.ddg.is.null(var)) return (TRUE)
+  else if (.ddg.is.na(var)) return (TRUE)
+  return (FALSE)
+}

--- a/scriptTests/FileNodes/rdt/expected_prov.json
+++ b/scriptTests/FileNodes/rdt/expected_prov.json
@@ -16,7 +16,7 @@
 		"rdt:p1": {
 			"rdt:name": "FileNodes.R",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": 1.06,
+			"rdt:elapsedTime": 0.932,
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -26,7 +26,7 @@
 		"rdt:p2": {
 			"rdt:name": "file.in <- url(\"http://www.mtholyoke.edu/index.html\")",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.12,
+			"rdt:elapsedTime": 1.001,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 2,
 			"rdt:startCol": 1,
@@ -36,7 +36,7 @@
 		"rdt:p3": {
 			"rdt:name": "df <- readLines(file.in, warn = FALSE)",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.23,
+			"rdt:elapsedTime": 1.084,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 3,
 			"rdt:startCol": 1,
@@ -46,7 +46,7 @@
 		"rdt:p4": {
 			"rdt:name": "close(file.in)",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.32,
+			"rdt:elapsedTime": 1.21,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 4,
 			"rdt:startCol": 1,
@@ -56,7 +56,7 @@
 		"rdt:p5": {
 			"rdt:name": "file.out <- file(\"test.dat\", \"w\")",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.32,
+			"rdt:elapsedTime": 1.214,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 7,
 			"rdt:startCol": 1,
@@ -66,7 +66,7 @@
 		"rdt:p6": {
 			"rdt:name": "writeLines(df, file.out)",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.36,
+			"rdt:elapsedTime": 1.258,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 8,
 			"rdt:startCol": 1,
@@ -76,7 +76,7 @@
 		"rdt:p7": {
 			"rdt:name": "close(file.out)",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.36,
+			"rdt:elapsedTime": 1.349,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 9,
 			"rdt:startCol": 1,
@@ -86,7 +86,7 @@
 		"rdt:p8": {
 			"rdt:name": "file.in <- unz(\"../ab.zip\", \"a.txt\")",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.37,
+			"rdt:elapsedTime": 1.372,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 18,
 			"rdt:startCol": 1,
@@ -96,7 +96,7 @@
 		"rdt:p9": {
 			"rdt:name": "df <- readLines(file.in)",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.37,
+			"rdt:elapsedTime": 1.431,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 19,
 			"rdt:startCol": 1,
@@ -106,7 +106,7 @@
 		"rdt:p10": {
 			"rdt:name": "close(file.in)",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.37,
+			"rdt:elapsedTime": 1.485,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 20,
 			"rdt:startCol": 1,
@@ -116,7 +116,7 @@
 		"rdt:p11": {
 			"rdt:name": "print(df)",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.37,
+			"rdt:elapsedTime": 1.49,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 21,
 			"rdt:startCol": 1,
@@ -126,7 +126,7 @@
 		"rdt:p12": {
 			"rdt:name": "x <- 1",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.37,
+			"rdt:elapsedTime": 1.494,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 24,
 			"rdt:startCol": 1,
@@ -136,7 +136,7 @@
 		"rdt:p13": {
 			"rdt:name": "write(x, \"x.csv\")",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.4,
+			"rdt:elapsedTime": 1.502,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 25,
 			"rdt:startCol": 1,
@@ -146,7 +146,7 @@
 		"rdt:p14": {
 			"rdt:name": "y <- read.table(\"x.csv\")",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.43,
+			"rdt:elapsedTime": 1.596,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 26,
 			"rdt:startCol": 1,
@@ -156,7 +156,7 @@
 		"rdt:p15": {
 			"rdt:name": "FileNodes.R",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": 1.45,
+			"rdt:elapsedTime": 1.601,
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -174,7 +174,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-05-07T12.13.41EDT",
+			"rdt:timestamp": "2019-05-17T17.01.23EDT",
 			"rdt:location": ""
 		},
 		"rdt:d2": {
@@ -185,18 +185,18 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-05-07T12.13.42EDT",
+			"rdt:timestamp": "2019-05-17T17.01.24EDT",
 			"rdt:location": ""
 		},
 		"rdt:d3": {
 			"rdt:name": "df",
 			"rdt:value": "data/3-df-PARTIAL.txt",
-			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[499], \"type\":[\"character\"]}",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[507], \"type\":[\"character\"]}",
 			"rdt:type": "Snapshot",
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-05-07T12.13.42EDT",
+			"rdt:timestamp": "2019-05-17T17.01.24EDT",
 			"rdt:location": ""
 		},
 		"rdt:d4": {
@@ -207,7 +207,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-05-07T12.13.42EDT",
+			"rdt:timestamp": "2019-05-17T17.01.25EDT",
 			"rdt:location": ""
 		},
 		"rdt:d5": {
@@ -218,7 +218,7 @@
 			"rdt:scope": "undefined",
 			"rdt:fromEnv": false,
 			"rdt:hash": "c25388200c950ec9bcb9ba08735d6f93",
-			"rdt:timestamp": "2019-05-07T12.13.42EDT",
+			"rdt:timestamp": "2019-05-17T17.01.25EDT",
 			"rdt:location": "[DIR]/rdt/test.dat"
 		},
 		"rdt:d6": {
@@ -229,7 +229,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-05-07T12.13.42EDT",
+			"rdt:timestamp": "2019-05-17T17.01.25EDT",
 			"rdt:location": ""
 		},
 		"rdt:d7": {
@@ -240,7 +240,7 @@
 			"rdt:scope": "undefined",
 			"rdt:fromEnv": false,
 			"rdt:hash": "0507c6013555380a3b051f6ebdf988dc",
-			"rdt:timestamp": "2019-05-07T12.13.42EDT",
+			"rdt:timestamp": "2019-05-17T17.01.25EDT",
 			"rdt:location": "[DIR]/ab.zip"
 		},
 		"rdt:d8": {
@@ -273,7 +273,7 @@
 			"rdt:scope": "undefined",
 			"rdt:fromEnv": false,
 			"rdt:hash": "91fd573a32f9ce88515c7de21cf0506c",
-			"rdt:timestamp": "2019-05-07T12.13.42EDT",
+			"rdt:timestamp": "2019-05-17T17.01.25EDT",
 			"rdt:location": "[DIR]/rdt/x.csv"
 		},
 		"rdt:d11": {
@@ -291,22 +291,22 @@
 		"rdt:environment": {
 			"rdt:name": "environment",
 			"rdt:architecture": "x86_64",
-			"rdt:operatingSystem": "mingw32",
+			"rdt:operatingSystem": "darwin15.6.0",
 			"rdt:language": "R",
-			"rdt:langVersion": "R version 3.5.2 (2018-12-20)",
+			"rdt:langVersion": "R version 3.6.0 (2019-04-26)",
 			"rdt:script": "[DIR]/FileNodes.R",
-			"rdt:scriptTimeStamp": "2019-04-25T17.09.17EDT",
+			"rdt:scriptTimeStamp": "2019-01-10T13.56.36EST",
 			"rdt:sourcedScripts": "",
 			"rdt:sourcedScriptTimeStamps": "",
 			"rdt:workingDirectory": "[DIR]/rdt",
 			"rdt:provDirectory": "[DIR]/rdt/prov_FileNodes",
-			"rdt:provTimestamp": "2019-05-07T12.13.40EDT",
+			"rdt:provTimestamp": "2019-05-17T17.01.22EDT",
 			"rdt:hashAlgorithm": "md5"
 		},
 
 		"rdt:l1": {
 			"name": "base",
-			"version": "3.5.2",
+			"version": "3.6.0",
 			"prov:type": {
 				"$": "prov:Collection",
 				"type": "xsd:QName"
@@ -314,7 +314,7 @@
 		},
 		"rdt:l2": {
 			"name": "datasets",
-			"version": "3.5.2",
+			"version": "3.6.0",
 			"prov:type": {
 				"$": "prov:Collection",
 				"type": "xsd:QName"
@@ -322,7 +322,7 @@
 		},
 		"rdt:l3": {
 			"name": "ggplot2",
-			"version": "3.1.0",
+			"version": "3.1.1",
 			"prov:type": {
 				"$": "prov:Collection",
 				"type": "xsd:QName"
@@ -330,7 +330,7 @@
 		},
 		"rdt:l4": {
 			"name": "graphics",
-			"version": "3.5.2",
+			"version": "3.6.0",
 			"prov:type": {
 				"$": "prov:Collection",
 				"type": "xsd:QName"
@@ -338,7 +338,7 @@
 		},
 		"rdt:l5": {
 			"name": "grDevices",
-			"version": "3.5.2",
+			"version": "3.6.0",
 			"prov:type": {
 				"$": "prov:Collection",
 				"type": "xsd:QName"
@@ -346,7 +346,7 @@
 		},
 		"rdt:l6": {
 			"name": "methods",
-			"version": "3.5.2",
+			"version": "3.6.0",
 			"prov:type": {
 				"$": "prov:Collection",
 				"type": "xsd:QName"
@@ -362,7 +362,7 @@
 		},
 		"rdt:l8": {
 			"name": "stats",
-			"version": "3.5.2",
+			"version": "3.6.0",
 			"prov:type": {
 				"$": "prov:Collection",
 				"type": "xsd:QName"
@@ -370,7 +370,7 @@
 		},
 		"rdt:l9": {
 			"name": "utils",
-			"version": "3.5.2",
+			"version": "3.6.0",
 			"prov:type": {
 				"$": "prov:Collection",
 				"type": "xsd:QName"

--- a/scriptTests/FileNodes/rdt/expected_test.out
+++ b/scriptTests/FileNodes/rdt/expected_test.out
@@ -1,2 +1,2 @@
 [1] "a <- 1"
-Execution Time = 2.582768
+Execution Time = 2.741066

--- a/scriptTests/FileNodes/rdtLite/expected_prov.json
+++ b/scriptTests/FileNodes/rdtLite/expected_prov.json
@@ -16,7 +16,7 @@
 		"rdt:p1": {
 			"rdt:name": "FileNodes.R",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": 1.06,
+			"rdt:elapsedTime": 0.957,
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -26,7 +26,7 @@
 		"rdt:p2": {
 			"rdt:name": "file.in <- url(\"http://www.mtholyoke.edu/index.html\")",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.12,
+			"rdt:elapsedTime": 1.013,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 2,
 			"rdt:startCol": 1,
@@ -36,7 +36,7 @@
 		"rdt:p3": {
 			"rdt:name": "df <- readLines(file.in, warn = FALSE)",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.31,
+			"rdt:elapsedTime": 1.099,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 3,
 			"rdt:startCol": 1,
@@ -46,7 +46,7 @@
 		"rdt:p4": {
 			"rdt:name": "close(file.in)",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.45,
+			"rdt:elapsedTime": 1.217,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 4,
 			"rdt:startCol": 1,
@@ -56,7 +56,7 @@
 		"rdt:p5": {
 			"rdt:name": "file.out <- file(\"test.dat\", \"w\")",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.47,
+			"rdt:elapsedTime": 1.22,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 7,
 			"rdt:startCol": 1,
@@ -66,7 +66,7 @@
 		"rdt:p6": {
 			"rdt:name": "writeLines(df, file.out)",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.57,
+			"rdt:elapsedTime": 1.258,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 8,
 			"rdt:startCol": 1,
@@ -76,7 +76,7 @@
 		"rdt:p7": {
 			"rdt:name": "close(file.out)",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.58,
+			"rdt:elapsedTime": 1.34,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 9,
 			"rdt:startCol": 1,
@@ -86,7 +86,7 @@
 		"rdt:p8": {
 			"rdt:name": "file.in <- unz(\"../ab.zip\", \"a.txt\")",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.65,
+			"rdt:elapsedTime": 1.358,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 18,
 			"rdt:startCol": 1,
@@ -96,7 +96,7 @@
 		"rdt:p9": {
 			"rdt:name": "df <- readLines(file.in)",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.68,
+			"rdt:elapsedTime": 1.414,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 19,
 			"rdt:startCol": 1,
@@ -106,7 +106,7 @@
 		"rdt:p10": {
 			"rdt:name": "close(file.in)",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.72,
+			"rdt:elapsedTime": 1.456,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 20,
 			"rdt:startCol": 1,
@@ -116,7 +116,7 @@
 		"rdt:p11": {
 			"rdt:name": "print(df)",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.74,
+			"rdt:elapsedTime": 1.459,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 21,
 			"rdt:startCol": 1,
@@ -126,7 +126,7 @@
 		"rdt:p12": {
 			"rdt:name": "x <- 1",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.74,
+			"rdt:elapsedTime": 1.462,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 24,
 			"rdt:startCol": 1,
@@ -136,7 +136,7 @@
 		"rdt:p13": {
 			"rdt:name": "write(x, \"x.csv\")",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.75,
+			"rdt:elapsedTime": 1.468,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 25,
 			"rdt:startCol": 1,
@@ -146,7 +146,7 @@
 		"rdt:p14": {
 			"rdt:name": "y <- read.table(\"x.csv\")",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": 1.8,
+			"rdt:elapsedTime": 1.552,
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 26,
 			"rdt:startCol": 1,
@@ -156,7 +156,7 @@
 		"rdt:p15": {
 			"rdt:name": "FileNodes.R",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": 1.81,
+			"rdt:elapsedTime": 1.558,
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -174,7 +174,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-05-07T12.08.20EDT",
+			"rdt:timestamp": "2019-05-17T15.08.54EDT",
 			"rdt:location": ""
 		},
 		"rdt:d2": {
@@ -185,18 +185,18 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-05-07T12.08.21EDT",
+			"rdt:timestamp": "2019-05-17T15.08.55EDT",
 			"rdt:location": ""
 		},
 		"rdt:d3": {
 			"rdt:name": "df",
 			"rdt:value": "data/3-df-PARTIAL.txt",
-			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[499], \"type\":[\"character\"]}",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[507], \"type\":[\"character\"]}",
 			"rdt:type": "Snapshot",
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-05-07T12.08.21EDT",
+			"rdt:timestamp": "2019-05-17T15.08.55EDT",
 			"rdt:location": ""
 		},
 		"rdt:d4": {
@@ -207,7 +207,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-05-07T12.08.21EDT",
+			"rdt:timestamp": "2019-05-17T15.08.55EDT",
 			"rdt:location": ""
 		},
 		"rdt:d5": {
@@ -218,7 +218,7 @@
 			"rdt:scope": "undefined",
 			"rdt:fromEnv": false,
 			"rdt:hash": "c25388200c950ec9bcb9ba08735d6f93",
-			"rdt:timestamp": "2019-05-07T12.08.21EDT",
+			"rdt:timestamp": "2019-05-17T15.08.55EDT",
 			"rdt:location": "[DIR]/rdtLite/test.dat"
 		},
 		"rdt:d6": {
@@ -229,7 +229,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-05-07T12.08.21EDT",
+			"rdt:timestamp": "2019-05-17T15.08.55EDT",
 			"rdt:location": ""
 		},
 		"rdt:d7": {
@@ -240,7 +240,7 @@
 			"rdt:scope": "undefined",
 			"rdt:fromEnv": false,
 			"rdt:hash": "0507c6013555380a3b051f6ebdf988dc",
-			"rdt:timestamp": "2019-05-07T12.08.21EDT",
+			"rdt:timestamp": "2019-05-17T15.08.55EDT",
 			"rdt:location": "[DIR]/ab.zip"
 		},
 		"rdt:d8": {
@@ -273,7 +273,7 @@
 			"rdt:scope": "undefined",
 			"rdt:fromEnv": false,
 			"rdt:hash": "91fd573a32f9ce88515c7de21cf0506c",
-			"rdt:timestamp": "2019-05-07T12.08.21EDT",
+			"rdt:timestamp": "2019-05-17T15.08.55EDT",
 			"rdt:location": "[DIR]/rdtLite/x.csv"
 		},
 		"rdt:d11": {
@@ -291,22 +291,22 @@
 		"rdt:environment": {
 			"rdt:name": "environment",
 			"rdt:architecture": "x86_64",
-			"rdt:operatingSystem": "mingw32",
+			"rdt:operatingSystem": "darwin15.6.0",
 			"rdt:language": "R",
-			"rdt:langVersion": "R version 3.5.2 (2018-12-20)",
+			"rdt:langVersion": "R version 3.6.0 (2019-04-26)",
 			"rdt:script": "[DIR]/FileNodes.R",
-			"rdt:scriptTimeStamp": "2019-04-25T17.09.17EDT",
+			"rdt:scriptTimeStamp": "2019-01-10T13.56.36EST",
 			"rdt:sourcedScripts": "",
 			"rdt:sourcedScriptTimeStamps": "",
 			"rdt:workingDirectory": "[DIR]/rdtLite",
 			"rdt:provDirectory": "[DIR]/rdtLite/prov_FileNodes",
-			"rdt:provTimestamp": "2019-05-07T12.08.19EDT",
+			"rdt:provTimestamp": "2019-05-17T15.08.53EDT",
 			"rdt:hashAlgorithm": "md5"
 		},
 
 		"rdt:l1": {
 			"name": "base",
-			"version": "3.5.2",
+			"version": "3.6.0",
 			"prov:type": {
 				"$": "prov:Collection",
 				"type": "xsd:QName"
@@ -314,7 +314,7 @@
 		},
 		"rdt:l2": {
 			"name": "datasets",
-			"version": "3.5.2",
+			"version": "3.6.0",
 			"prov:type": {
 				"$": "prov:Collection",
 				"type": "xsd:QName"
@@ -322,7 +322,7 @@
 		},
 		"rdt:l3": {
 			"name": "ggplot2",
-			"version": "3.1.0",
+			"version": "3.1.1",
 			"prov:type": {
 				"$": "prov:Collection",
 				"type": "xsd:QName"
@@ -330,7 +330,7 @@
 		},
 		"rdt:l4": {
 			"name": "graphics",
-			"version": "3.5.2",
+			"version": "3.6.0",
 			"prov:type": {
 				"$": "prov:Collection",
 				"type": "xsd:QName"
@@ -338,7 +338,7 @@
 		},
 		"rdt:l5": {
 			"name": "grDevices",
-			"version": "3.5.2",
+			"version": "3.6.0",
 			"prov:type": {
 				"$": "prov:Collection",
 				"type": "xsd:QName"
@@ -346,7 +346,7 @@
 		},
 		"rdt:l6": {
 			"name": "methods",
-			"version": "3.5.2",
+			"version": "3.6.0",
 			"prov:type": {
 				"$": "prov:Collection",
 				"type": "xsd:QName"
@@ -362,7 +362,7 @@
 		},
 		"rdt:l8": {
 			"name": "stats",
-			"version": "3.5.2",
+			"version": "3.6.0",
 			"prov:type": {
 				"$": "prov:Collection",
 				"type": "xsd:QName"
@@ -370,7 +370,7 @@
 		},
 		"rdt:l9": {
 			"name": "utils",
-			"version": "3.5.2",
+			"version": "3.6.0",
 			"prov:type": {
 				"$": "prov:Collection",
 				"type": "xsd:QName"

--- a/scriptTests/FileNodes/rdtLite/expected_test.out
+++ b/scriptTests/FileNodes/rdtLite/expected_test.out
@@ -1,2 +1,2 @@
 [1] "a <- 1"
-Execution Time = 2.679565
+Execution Time = 2.242602


### PR DESCRIPTION
New cran checks produced warnings when our examples were run.  The problem was that we were using is.null and is.na to check whether a variable was null or NA.  In the case that the value contained a vector, these functions return a vector of logical values, instead of a single logical value.  This caused a warning when a single logical value was expected.

With R 3.6, the cran checks began looking for this problem.
