### PR TITLE
Fixes issue 550

### DIFF
--- a/R/DataNodes.R
+++ b/R/DataNodes.R
@@ -184,6 +184,8 @@
 
 #' .ddg.data.number retrieves the number of the nearest preceding
 #' current matching data node. It returns zero if no match is found.
+#' This occurs if the variable is in a scope that is not visible at
+#' the current line of code.
 #' @param dname data node name.
 #' @param dscope (optional) data node scope.  If not provided, it uses
 #' the closest scope in which dname is found
@@ -201,9 +203,6 @@
     return (matching$ddg.num[nrow(matching)])
   }
   
-  # Error message if no match found.
-  error.msg <- paste("No data node found for", dname)
-  .ddg.insert.error.message(error.msg)
   return(0)
 }
 

--- a/R/RDataTracker_core.R
+++ b/R/RDataTracker_core.R
@@ -471,10 +471,19 @@
 .ddg.save.var <- function(var, env=NULL, scope=NULL) {
   if (is.null(env)) {
     env <- .ddg.get.env(var)
+    
+    # If no environment is found defining this variable, do not 
+    # save it.  It means that the variable is from a scope that
+    # is not available at the current line of code, such as a 
+    # non-local, yet not global scope.
+    if (is.null(env)) {
+      return()
+    }
   }
   if (is.null(scope)) {
     scope <- .ddg.get.scope(var, env=env)
   }
+
   
   # Special operators are defined by enclosing the name in `.  However,
   # the R parser drops those characters when we deparse, so when we parse

--- a/scriptTests/AssignOperators/AssignOperators.R
+++ b/scriptTests/AssignOperators/AssignOperators.R
@@ -145,6 +145,10 @@ stopifnot( m == 14 )
 # nested function environment - overriding exising variable
 # assignment statement in nested function is not the last statement 
 # tests .ddg.parse.commands
+#
+# Works with rdtLite.  
+# ***ERROR: With rdt, there should be an edge from the definition of fn7a to where
+# it is called but that edge is missing.
 fn7 <- function()
 {
   n <- 15

--- a/scriptTests/AssignOperators/AssignOperators.R
+++ b/scriptTests/AssignOperators/AssignOperators.R
@@ -145,23 +145,22 @@ stopifnot( m == 14 )
 # nested function environment - overriding exising variable
 # assignment statement in nested function is not the last statement 
 # tests .ddg.parse.commands
-# DOES NOT WORK!!!
-#fn7 <- function()
-#{
-#  n <- 15
-#  
-#  fn <- function()
-#  {
-#    n <<- 16
-#    stopifnot( n == 16 )
-#  }
-#  
-#  fn()
-#  stopifnot( n == 16 )
-#}
+fn7 <- function()
+{
+  n <- 15
+  
+  fn7a <- function()
+  {
+    n <<- 16
+    stopifnot( n == 16 )
+  }
+  
+  fn7a()
+  stopifnot( n == 16 )
+}
 
-#fn7()
-#stopifnot( ! exists("n") )
+fn7()
+stopifnot( ! exists("n") )
 
 
 # nested function environment - overriding existing variable

--- a/scriptTests/AssignOperators/rdt/expected_prov.json
+++ b/scriptTests/AssignOperators/rdt/expected_prov.json
@@ -16,7 +16,7 @@
 		"rdt:p1": {
 			"rdt:name": "AssignOperators.R",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.775",
+			"rdt:elapsedTime": "0.778",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -26,7 +26,7 @@
 		"rdt:p2": {
 			"rdt:name": "a = 1",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.186",
+			"rdt:elapsedTime": "0.197",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 11,
 			"rdt:startCol": 1,
@@ -36,7 +36,7 @@
 		"rdt:p3": {
 			"rdt:name": "stopifnot( a == 1 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.008",
+			"rdt:elapsedTime": "0.009",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 12,
 			"rdt:startCol": 1,
@@ -46,7 +46,7 @@
 		"rdt:p4": {
 			"rdt:name": "fn1 <- function()\n{\n  b = 2\n  stopifnot( b == 2 )\n}",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 16,
 			"rdt:startCol": 1,
@@ -56,7 +56,7 @@
 		"rdt:p5": {
 			"rdt:name": "fn1()",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.038",
+			"rdt:elapsedTime": "0.031",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -96,7 +96,7 @@
 		"rdt:p9": {
 			"rdt:name": "fn1()",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.006",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -116,7 +116,7 @@
 		"rdt:p11": {
 			"rdt:name": "fn2 <- function()\n{\n  d = 3\n  \n  fn <- function()\n  {\n\td ",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 28,
 			"rdt:startCol": 1,
@@ -126,7 +126,7 @@
 		"rdt:p12": {
 			"rdt:name": "fn2()",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.048",
+			"rdt:elapsedTime": "0.046",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -136,7 +136,7 @@
 		"rdt:p13": {
 			"rdt:name": "fn2",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.0",
+			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -156,7 +156,7 @@
 		"rdt:p15": {
 			"rdt:name": "fn <- function()\n  {\n\td = 4\n  }",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.006",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 32,
 			"rdt:startCol": 3,
@@ -166,7 +166,7 @@
 		"rdt:p16": {
 			"rdt:name": "fn()",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.014",
+			"rdt:elapsedTime": "0.013",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -196,7 +196,7 @@
 		"rdt:p19": {
 			"rdt:name": "fn()",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -216,7 +216,7 @@
 		"rdt:p21": {
 			"rdt:name": "fn2()",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -226,7 +226,7 @@
 		"rdt:p22": {
 			"rdt:name": "stopifnot( ! exists(\"d\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.001",
+			"rdt:elapsedTime": "0.0",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 42,
 			"rdt:startCol": 1,
@@ -236,7 +236,7 @@
 		"rdt:p23": {
 			"rdt:name": "env1 <- new.env()",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.003",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 46,
 			"rdt:startCol": 1,
@@ -246,7 +246,7 @@
 		"rdt:p24": {
 			"rdt:name": "env1$e = 5",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.004",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 47,
 			"rdt:startCol": 1,
@@ -256,7 +256,7 @@
 		"rdt:p25": {
 			"rdt:name": "stopifnot( env1$e == 5 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.008",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 49,
 			"rdt:startCol": 1,
@@ -266,7 +266,7 @@
 		"rdt:p26": {
 			"rdt:name": "stopifnot( ! exists(\"e\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 50,
 			"rdt:startCol": 1,
@@ -296,7 +296,7 @@
 		"rdt:p29": {
 			"rdt:name": "env2$env$f = 6",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.011",
+			"rdt:elapsedTime": "0.007",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 56,
 			"rdt:startCol": 1,
@@ -316,7 +316,7 @@
 		"rdt:p31": {
 			"rdt:name": "stopifnot( ! exists(\"env2$f\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 59,
 			"rdt:startCol": 1,
@@ -356,7 +356,7 @@
 		"rdt:p35": {
 			"rdt:name": "fn3 <- function()\n{\n  h <- 8\n  stopifnot( h == 8 )\n}",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 71,
 			"rdt:startCol": 1,
@@ -366,7 +366,7 @@
 		"rdt:p36": {
 			"rdt:name": "fn3()",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.01",
+			"rdt:elapsedTime": "0.011",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -376,7 +376,7 @@
 		"rdt:p37": {
 			"rdt:name": "fn3",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.001",
+			"rdt:elapsedTime": "0.0",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -386,7 +386,7 @@
 		"rdt:p38": {
 			"rdt:name": "h <- 8",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.001",
+			"rdt:elapsedTime": "0.002",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 73,
 			"rdt:startCol": 3,
@@ -396,7 +396,7 @@
 		"rdt:p39": {
 			"rdt:name": "stopifnot( h == 8 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.004",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 74,
 			"rdt:startCol": 3,
@@ -406,7 +406,7 @@
 		"rdt:p40": {
 			"rdt:name": "fn3()",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.009",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -416,7 +416,7 @@
 		"rdt:p41": {
 			"rdt:name": "stopifnot( ! exists(\"h\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.001",
+			"rdt:elapsedTime": "0.0",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 78,
 			"rdt:startCol": 1,
@@ -426,7 +426,7 @@
 		"rdt:p42": {
 			"rdt:name": "fn4 <- function()\n{\n  i <- 9\n  \n  fn <- function()\n  {\n\ti",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 83,
 			"rdt:startCol": 1,
@@ -466,7 +466,7 @@
 		"rdt:p46": {
 			"rdt:name": "fn <- function()\n  {\n\ti <- 10\n  }",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.008",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 87,
 			"rdt:startCol": 3,
@@ -476,7 +476,7 @@
 		"rdt:p47": {
 			"rdt:name": "fn()",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.013",
+			"rdt:elapsedTime": "0.012",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -486,7 +486,7 @@
 		"rdt:p48": {
 			"rdt:name": "fn",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.001",
+			"rdt:elapsedTime": "0.0",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -496,7 +496,7 @@
 		"rdt:p49": {
 			"rdt:name": "i <- 10",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.001",
+			"rdt:elapsedTime": "0.002",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 89,
 			"rdt:startCol": 5,
@@ -506,7 +506,7 @@
 		"rdt:p50": {
 			"rdt:name": "fn()",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.006",
+			"rdt:elapsedTime": "0.007",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -516,7 +516,7 @@
 		"rdt:p51": {
 			"rdt:name": "stopifnot( i == 9 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.001",
+			"rdt:elapsedTime": "0.002",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 93,
 			"rdt:startCol": 3,
@@ -566,7 +566,7 @@
 		"rdt:p56": {
 			"rdt:name": "stopifnot( env3$j == 11 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 104,
 			"rdt:startCol": 1,
@@ -586,7 +586,7 @@
 		"rdt:p58": {
 			"rdt:name": "env4 <- new.env()",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.007",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 109,
 			"rdt:startCol": 1,
@@ -626,7 +626,7 @@
 		"rdt:p62": {
 			"rdt:name": "stopifnot( ! exists(\"env4$k\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.009",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 114,
 			"rdt:startCol": 1,
@@ -646,7 +646,7 @@
 		"rdt:p64": {
 			"rdt:name": "fn5 <- function()\n{\n  l <<- 13\n  stopifnot( l == 13 )\n}",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.003",
+			"rdt:elapsedTime": "0.004",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 124,
 			"rdt:startCol": 1,
@@ -656,7 +656,7 @@
 		"rdt:p65": {
 			"rdt:name": "fn5()",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.011",
+			"rdt:elapsedTime": "0.01",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -686,7 +686,7 @@
 		"rdt:p68": {
 			"rdt:name": "stopifnot( l == 13 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.007",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 127,
 			"rdt:startCol": 3,
@@ -696,7 +696,7 @@
 		"rdt:p69": {
 			"rdt:name": "fn5()",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -716,7 +716,7 @@
 		"rdt:p71": {
 			"rdt:name": "fn6 <- function()\n{\n  m <<- 14\n}",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 136,
 			"rdt:startCol": 1,
@@ -726,7 +726,7 @@
 		"rdt:p72": {
 			"rdt:name": "fn6()",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.01",
+			"rdt:elapsedTime": "0.011",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -736,7 +736,7 @@
 		"rdt:p73": {
 			"rdt:name": "fn6",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.001",
+			"rdt:elapsedTime": "0.0",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -746,7 +746,7 @@
 		"rdt:p74": {
 			"rdt:name": "m <<- 14",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.002",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 138,
 			"rdt:startCol": 3,
@@ -756,7 +756,7 @@
 		"rdt:p75": {
 			"rdt:name": "fn6()",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -774,19 +774,19 @@
 			"rdt:endCol": 20
 		},
 		"rdt:p77": {
-			"rdt:name": "fn9 <- function()\n{\n  fn <- function()\n  {\n\tp <<- 19\n\t",
+			"rdt:name": "fn7 <- function()\n{\n  n <- 15\n  \n  fn7a <- function()\n  {\n  ",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.007",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 191,
+			"rdt:startLine": 148,
 			"rdt:startCol": 1,
-			"rdt:endLine": 201,
+			"rdt:endLine": 160,
 			"rdt:endCol": 1
 		},
 		"rdt:p78": {
-			"rdt:name": "fn9()",
+			"rdt:name": "fn7()",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.02",
+			"rdt:elapsedTime": "0.015",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -794,7 +794,7 @@
 			"rdt:endCol": "NA"
 		},
 		"rdt:p79": {
-			"rdt:name": "fn9",
+			"rdt:name": "fn7",
 			"rdt:type": "Operation",
 			"rdt:elapsedTime": "0.0",
 			"rdt:scriptNum": "NA",
@@ -804,29 +804,29 @@
 			"rdt:endCol": "NA"
 		},
 		"rdt:p80": {
-			"rdt:name": "fn <- function() {\tp <<- 19\tstopifnot(p == 19)}",
+			"rdt:name": "n <- 15",
 			"rdt:type": "Operation",
 			"rdt:elapsedTime": "0.002",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": "NA",
-			"rdt:startCol": "NA",
-			"rdt:endLine": "NA",
-			"rdt:endCol": "NA"
+			"rdt:startLine": 150,
+			"rdt:startCol": 3,
+			"rdt:endLine": 150,
+			"rdt:endCol": 9
 		},
 		"rdt:p81": {
-			"rdt:name": "fn()",
-			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.012",
-			"rdt:scriptNum": "NA",
-			"rdt:startLine": "NA",
-			"rdt:startCol": "NA",
-			"rdt:endLine": "NA",
-			"rdt:endCol": "NA"
+			"rdt:name": "fn7a <- function()\n  {\n\tn <<- 16\n\tstopifnot( n == 16 )",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": "0.005",
+			"rdt:scriptNum": 1,
+			"rdt:startLine": 152,
+			"rdt:startCol": 3,
+			"rdt:endLine": 156,
+			"rdt:endCol": 3
 		},
 		"rdt:p82": {
-			"rdt:name": "fn",
-			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.0",
+			"rdt:name": "fn7a()",
+			"rdt:type": "Start",
+			"rdt:elapsedTime": "0.011",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -834,26 +834,156 @@
 			"rdt:endCol": "NA"
 		},
 		"rdt:p83": {
-			"rdt:name": "p <<- 19",
+			"rdt:name": "fn7a",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.002",
-			"rdt:scriptNum": 1,
+			"rdt:elapsedTime": "0.001",
+			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
 			"rdt:endLine": "NA",
 			"rdt:endCol": "NA"
 		},
 		"rdt:p84": {
-			"rdt:name": "stopifnot(p == 19)",
+			"rdt:name": "n <<- 16",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": "0.001",
+			"rdt:scriptNum": 1,
+			"rdt:startLine": 154,
+			"rdt:startCol": 5,
+			"rdt:endLine": 154,
+			"rdt:endCol": 12
+		},
+		"rdt:p85": {
+			"rdt:name": "stopifnot( n == 16 )",
 			"rdt:type": "Operation",
 			"rdt:elapsedTime": "0.005",
+			"rdt:scriptNum": 1,
+			"rdt:startLine": 155,
+			"rdt:startCol": 5,
+			"rdt:endLine": 155,
+			"rdt:endCol": 24
+		},
+		"rdt:p86": {
+			"rdt:name": "fn7a()",
+			"rdt:type": "Finish",
+			"rdt:elapsedTime": "0.006",
+			"rdt:scriptNum": "NA",
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"rdt:p87": {
+			"rdt:name": "stopifnot( n == 16 )",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": "0.002",
+			"rdt:scriptNum": 1,
+			"rdt:startLine": 159,
+			"rdt:startCol": 3,
+			"rdt:endLine": 159,
+			"rdt:endCol": 22
+		},
+		"rdt:p88": {
+			"rdt:name": "fn7()",
+			"rdt:type": "Finish",
+			"rdt:elapsedTime": "0.005",
+			"rdt:scriptNum": "NA",
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"rdt:p89": {
+			"rdt:name": "stopifnot( ! exists(\"n\") )",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": "0.001",
+			"rdt:scriptNum": 1,
+			"rdt:startLine": 163,
+			"rdt:startCol": 1,
+			"rdt:endLine": 163,
+			"rdt:endCol": 26
+		},
+		"rdt:p90": {
+			"rdt:name": "fn9 <- function()\n{\n  fn <- function()\n  {\n\tp <<- 19\n\t",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": "0.004",
+			"rdt:scriptNum": 1,
+			"rdt:startLine": 190,
+			"rdt:startCol": 1,
+			"rdt:endLine": 200,
+			"rdt:endCol": 1
+		},
+		"rdt:p91": {
+			"rdt:name": "fn9()",
+			"rdt:type": "Start",
+			"rdt:elapsedTime": "0.02",
+			"rdt:scriptNum": "NA",
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"rdt:p92": {
+			"rdt:name": "fn9",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": "0.001",
+			"rdt:scriptNum": "NA",
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"rdt:p93": {
+			"rdt:name": "fn <- function() {\tp <<- 19\tstopifnot(p == 19)}",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
 			"rdt:endLine": "NA",
 			"rdt:endCol": "NA"
 		},
-		"rdt:p85": {
+		"rdt:p94": {
+			"rdt:name": "fn()",
+			"rdt:type": "Start",
+			"rdt:elapsedTime": "0.015",
+			"rdt:scriptNum": "NA",
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"rdt:p95": {
+			"rdt:name": "fn",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": "0.001",
+			"rdt:scriptNum": "NA",
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"rdt:p96": {
+			"rdt:name": "p <<- 19",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": "0.001",
+			"rdt:scriptNum": 1,
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"rdt:p97": {
+			"rdt:name": "stopifnot(p == 19)",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": "0.006",
+			"rdt:scriptNum": 1,
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"rdt:p98": {
 			"rdt:name": "fn()",
 			"rdt:type": "Finish",
 			"rdt:elapsedTime": "0.007",
@@ -863,67 +993,67 @@
 			"rdt:endLine": "NA",
 			"rdt:endCol": "NA"
 		},
-		"rdt:p86": {
+		"rdt:p99": {
 			"rdt:name": "stopifnot(p == 19)",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.001",
+			"rdt:elapsedTime": "0.002",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
 			"rdt:endLine": "NA",
 			"rdt:endCol": "NA"
 		},
-		"rdt:p87": {
+		"rdt:p100": {
 			"rdt:name": "fn9()",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.006",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
 			"rdt:endLine": "NA",
 			"rdt:endCol": "NA"
 		},
-		"rdt:p88": {
+		"rdt:p101": {
 			"rdt:name": "stopifnot( p == 19 )",
 			"rdt:type": "Operation",
 			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 204,
+			"rdt:startLine": 203,
 			"rdt:startCol": 1,
-			"rdt:endLine": 204,
+			"rdt:endLine": 203,
 			"rdt:endCol": 20
 		},
-		"rdt:p89": {
+		"rdt:p102": {
 			"rdt:name": "fn10 <- function()\n{\n  fn <- function()\n  {\n\tr <<- 20\n  }",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 211,
+			"rdt:startLine": 210,
 			"rdt:startCol": 1,
-			"rdt:endLine": 220,
+			"rdt:endLine": 219,
 			"rdt:endCol": 1
 		},
-		"rdt:p90": {
+		"rdt:p103": {
 			"rdt:name": "fn10()",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.017",
+			"rdt:elapsedTime": "0.015",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
 			"rdt:endLine": "NA",
 			"rdt:endCol": "NA"
 		},
-		"rdt:p91": {
+		"rdt:p104": {
 			"rdt:name": "fn10",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.0",
+			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
 			"rdt:endLine": "NA",
 			"rdt:endCol": "NA"
 		},
-		"rdt:p92": {
+		"rdt:p105": {
 			"rdt:name": "fn <- function() {\tr <<- 20}",
 			"rdt:type": "Operation",
 			"rdt:elapsedTime": "0.002",
@@ -933,27 +1063,27 @@
 			"rdt:endLine": "NA",
 			"rdt:endCol": "NA"
 		},
-		"rdt:p93": {
+		"rdt:p106": {
 			"rdt:name": "fn()",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.016",
+			"rdt:elapsedTime": "0.023",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
 			"rdt:endLine": "NA",
 			"rdt:endCol": "NA"
 		},
-		"rdt:p94": {
+		"rdt:p107": {
 			"rdt:name": "fn",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.001",
+			"rdt:elapsedTime": "0.0",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
 			"rdt:endLine": "NA",
 			"rdt:endCol": "NA"
 		},
-		"rdt:p95": {
+		"rdt:p108": {
 			"rdt:name": "r <<- 20",
 			"rdt:type": "Operation",
 			"rdt:elapsedTime": "0.002",
@@ -963,28 +1093,8 @@
 			"rdt:endLine": "NA",
 			"rdt:endCol": "NA"
 		},
-		"rdt:p96": {
+		"rdt:p109": {
 			"rdt:name": "fn()",
-			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.007",
-			"rdt:scriptNum": "NA",
-			"rdt:startLine": "NA",
-			"rdt:startCol": "NA",
-			"rdt:endLine": "NA",
-			"rdt:endCol": "NA"
-		},
-		"rdt:p97": {
-			"rdt:name": "stopifnot(r == 20)",
-			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.002",
-			"rdt:scriptNum": 1,
-			"rdt:startLine": "NA",
-			"rdt:startCol": "NA",
-			"rdt:endLine": "NA",
-			"rdt:endCol": "NA"
-		},
-		"rdt:p98": {
-			"rdt:name": "fn10()",
 			"rdt:type": "Finish",
 			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": "NA",
@@ -993,17 +1103,37 @@
 			"rdt:endLine": "NA",
 			"rdt:endCol": "NA"
 		},
-		"rdt:p99": {
+		"rdt:p110": {
+			"rdt:name": "stopifnot(r == 20)",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": "0.003",
+			"rdt:scriptNum": 1,
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"rdt:p111": {
+			"rdt:name": "fn10()",
+			"rdt:type": "Finish",
+			"rdt:elapsedTime": "0.007",
+			"rdt:scriptNum": "NA",
+			"rdt:startLine": "NA",
+			"rdt:startCol": "NA",
+			"rdt:endLine": "NA",
+			"rdt:endCol": "NA"
+		},
+		"rdt:p112": {
 			"rdt:name": "stopifnot( r == 20 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.0",
+			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 223,
+			"rdt:startLine": 222,
 			"rdt:startCol": 1,
-			"rdt:endLine": 223,
+			"rdt:endLine": 222,
 			"rdt:endCol": 20
 		},
-		"rdt:p100": {
+		"rdt:p113": {
 			"rdt:name": "AssignOperators.R",
 			"rdt:type": "Finish",
 			"rdt:elapsedTime": "0.005",
@@ -1035,7 +1165,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T15.51.36EDT",
+			"rdt:timestamp": "2019-07-23T14.58.17EDT",
 			"rdt:location": ""
 		},
 		"rdt:d3": {
@@ -1043,7 +1173,7 @@
 			"rdt:value": "2",
 			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
 			"rdt:type": "Data",
-			"rdt:scope": "0x7f96f850e740",
+			"rdt:scope": "0x7ffa296f9ae8",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
 			"rdt:timestamp": "",
@@ -1068,7 +1198,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T15.51.36EDT",
+			"rdt:timestamp": "2019-07-23T14.58.17EDT",
 			"rdt:location": ""
 		},
 		"rdt:d6": {
@@ -1076,7 +1206,7 @@
 			"rdt:value": "3",
 			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
 			"rdt:type": "Data",
-			"rdt:scope": "0x7f96f794b120",
+			"rdt:scope": "0x7ffa25a4d958",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
 			"rdt:timestamp": "",
@@ -1087,10 +1217,10 @@
 			"rdt:value": "data/7-fn.R",
 			"rdt:valType": "function",
 			"rdt:type": "Snapshot",
-			"rdt:scope": "0x7f96f794b120",
+			"rdt:scope": "0x7ffa25a4d958",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T15.51.36EDT",
+			"rdt:timestamp": "2019-07-23T14.58.17EDT",
 			"rdt:location": ""
 		},
 		"rdt:d8": {
@@ -1098,7 +1228,7 @@
 			"rdt:value": "4",
 			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
 			"rdt:type": "Data",
-			"rdt:scope": "0x7f96f200bf80",
+			"rdt:scope": "0x7ffa2bd06180",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
 			"rdt:timestamp": "",
@@ -1128,7 +1258,7 @@
 		},
 		"rdt:d11": {
 			"rdt:name": "env1",
-			"rdt:value": "<environment: 0x7f96f4d7df50>",
+			"rdt:value": "<environment: 0x7ffa2a383540>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1139,7 +1269,7 @@
 		},
 		"rdt:d12": {
 			"rdt:name": "env1",
-			"rdt:value": "<environment: 0x7f96f4d7df50>",
+			"rdt:value": "<environment: 0x7ffa2a383540>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1150,7 +1280,7 @@
 		},
 		"rdt:d13": {
 			"rdt:name": "env2",
-			"rdt:value": "<environment: 0x7f96f1ecdf38>",
+			"rdt:value": "<environment: 0x7ffa2a69a468>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1161,7 +1291,7 @@
 		},
 		"rdt:d14": {
 			"rdt:name": "env2",
-			"rdt:value": "<environment: 0x7f96f1ecdf38>",
+			"rdt:value": "<environment: 0x7ffa2a69a468>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1172,7 +1302,7 @@
 		},
 		"rdt:d15": {
 			"rdt:name": "env2",
-			"rdt:value": "<environment: 0x7f96f1ecdf38>",
+			"rdt:value": "<environment: 0x7ffa2a69a468>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1200,7 +1330,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T15.51.36EDT",
+			"rdt:timestamp": "2019-07-23T14.58.18EDT",
 			"rdt:location": ""
 		},
 		"rdt:d18": {
@@ -1208,7 +1338,7 @@
 			"rdt:value": "8",
 			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
 			"rdt:type": "Data",
-			"rdt:scope": "0x7f96f4b74618",
+			"rdt:scope": "0x7ffa2a2ea200",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
 			"rdt:timestamp": "",
@@ -1233,7 +1363,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T15.51.36EDT",
+			"rdt:timestamp": "2019-07-23T14.58.18EDT",
 			"rdt:location": ""
 		},
 		"rdt:d21": {
@@ -1241,7 +1371,7 @@
 			"rdt:value": "9",
 			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
 			"rdt:type": "Data",
-			"rdt:scope": "0x7f96f6b45058",
+			"rdt:scope": "0x7ffa2a2203c0",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
 			"rdt:timestamp": "",
@@ -1252,10 +1382,10 @@
 			"rdt:value": "data/22-fn.R",
 			"rdt:valType": "function",
 			"rdt:type": "Snapshot",
-			"rdt:scope": "0x7f96f6b45058",
+			"rdt:scope": "0x7ffa2a2203c0",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T15.51.36EDT",
+			"rdt:timestamp": "2019-07-23T14.58.18EDT",
 			"rdt:location": ""
 		},
 		"rdt:d23": {
@@ -1263,7 +1393,7 @@
 			"rdt:value": "10",
 			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
 			"rdt:type": "Data",
-			"rdt:scope": "0x7f96f6f2afb0",
+			"rdt:scope": "0x7ffa2b8d5a48",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
 			"rdt:timestamp": "",
@@ -1293,7 +1423,7 @@
 		},
 		"rdt:d26": {
 			"rdt:name": "env3",
-			"rdt:value": "<environment: 0x7f96f49a4f90>",
+			"rdt:value": "<environment: 0x7ffa2bf3ed20>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1304,7 +1434,7 @@
 		},
 		"rdt:d27": {
 			"rdt:name": "env3",
-			"rdt:value": "<environment: 0x7f96f49a4f90>",
+			"rdt:value": "<environment: 0x7ffa2bf3ed20>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1315,7 +1445,7 @@
 		},
 		"rdt:d28": {
 			"rdt:name": "env4",
-			"rdt:value": "<environment: 0x7f96f4fe9838>",
+			"rdt:value": "<environment: 0x7ffa2b491c30>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1326,7 +1456,7 @@
 		},
 		"rdt:d29": {
 			"rdt:name": "env4",
-			"rdt:value": "<environment: 0x7f96f4fe9838>",
+			"rdt:value": "<environment: 0x7ffa2b491c30>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1337,7 +1467,7 @@
 		},
 		"rdt:d30": {
 			"rdt:name": "env4",
-			"rdt:value": "<environment: 0x7f96f4fe9838>",
+			"rdt:value": "<environment: 0x7ffa2b491c30>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1354,7 +1484,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T15.51.37EDT",
+			"rdt:timestamp": "2019-07-23T14.58.18EDT",
 			"rdt:location": ""
 		},
 		"rdt:d32": {
@@ -1387,7 +1517,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T15.51.37EDT",
+			"rdt:timestamp": "2019-07-23T14.58.18EDT",
 			"rdt:location": ""
 		},
 		"rdt:d35": {
@@ -1413,28 +1543,94 @@
 			"rdt:location": ""
 		},
 		"rdt:d37": {
-			"rdt:name": "fn9",
-			"rdt:value": "data/37-fn9.R",
+			"rdt:name": "fn7",
+			"rdt:value": "data/37-fn7.R",
 			"rdt:valType": "function",
 			"rdt:type": "Snapshot",
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T15.51.37EDT",
+			"rdt:timestamp": "2019-07-23T14.58.18EDT",
 			"rdt:location": ""
 		},
 		"rdt:d38": {
-			"rdt:name": "fn",
-			"rdt:value": "data/38-fn.R",
-			"rdt:valType": "function",
-			"rdt:type": "Snapshot",
-			"rdt:scope": "0x7f96f7ed0d20",
+			"rdt:name": "n",
+			"rdt:value": "15",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "0x7ffa275eb1e8",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T15.51.37EDT",
+			"rdt:timestamp": "",
 			"rdt:location": ""
 		},
 		"rdt:d39": {
+			"rdt:name": "fn7a",
+			"rdt:value": "data/39-fn7a.R",
+			"rdt:valType": "function",
+			"rdt:type": "Snapshot",
+			"rdt:scope": "0x7ffa275eb1e8",
+			"rdt:fromEnv": false,
+			"rdt:hash": "",
+			"rdt:timestamp": "2019-07-23T14.58.18EDT",
+			"rdt:location": ""
+		},
+		"rdt:d40": {
+			"rdt:name": "n",
+			"rdt:value": "16",
+			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
+			"rdt:type": "Data",
+			"rdt:scope": "0x7ffa275eb1e8",
+			"rdt:fromEnv": false,
+			"rdt:hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"rdt:d41": {
+			"rdt:name": "fn7a() return",
+			"rdt:value": "NULL",
+			"rdt:valType": "null",
+			"rdt:type": "Data",
+			"rdt:scope": "",
+			"rdt:fromEnv": false,
+			"rdt:hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"rdt:d42": {
+			"rdt:name": "fn7() return",
+			"rdt:value": "NULL",
+			"rdt:valType": "null",
+			"rdt:type": "Data",
+			"rdt:scope": "R_GlobalEnv",
+			"rdt:fromEnv": false,
+			"rdt:hash": "",
+			"rdt:timestamp": "",
+			"rdt:location": ""
+		},
+		"rdt:d43": {
+			"rdt:name": "fn9",
+			"rdt:value": "data/43-fn9.R",
+			"rdt:valType": "function",
+			"rdt:type": "Snapshot",
+			"rdt:scope": "R_GlobalEnv",
+			"rdt:fromEnv": false,
+			"rdt:hash": "",
+			"rdt:timestamp": "2019-07-23T14.58.18EDT",
+			"rdt:location": ""
+		},
+		"rdt:d44": {
+			"rdt:name": "fn",
+			"rdt:value": "data/44-fn.R",
+			"rdt:valType": "function",
+			"rdt:type": "Snapshot",
+			"rdt:scope": "0x7ffa2af80010",
+			"rdt:fromEnv": false,
+			"rdt:hash": "",
+			"rdt:timestamp": "2019-07-23T14.58.18EDT",
+			"rdt:location": ""
+		},
+		"rdt:d45": {
 			"rdt:name": "p",
 			"rdt:value": "19",
 			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
@@ -1445,7 +1641,7 @@
 			"rdt:timestamp": "",
 			"rdt:location": ""
 		},
-		"rdt:d40": {
+		"rdt:d46": {
 			"rdt:name": "fn() return",
 			"rdt:value": "NULL",
 			"rdt:valType": "null",
@@ -1456,7 +1652,7 @@
 			"rdt:timestamp": "",
 			"rdt:location": ""
 		},
-		"rdt:d41": {
+		"rdt:d47": {
 			"rdt:name": "fn9() return",
 			"rdt:value": "NULL",
 			"rdt:valType": "null",
@@ -1467,29 +1663,29 @@
 			"rdt:timestamp": "",
 			"rdt:location": ""
 		},
-		"rdt:d42": {
+		"rdt:d48": {
 			"rdt:name": "fn10",
-			"rdt:value": "data/42-fn10.R",
+			"rdt:value": "data/48-fn10.R",
 			"rdt:valType": "function",
 			"rdt:type": "Snapshot",
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T15.51.37EDT",
+			"rdt:timestamp": "2019-07-23T14.58.18EDT",
 			"rdt:location": ""
 		},
-		"rdt:d43": {
+		"rdt:d49": {
 			"rdt:name": "fn",
-			"rdt:value": "data/43-fn.R",
+			"rdt:value": "data/49-fn.R",
 			"rdt:valType": "function",
 			"rdt:type": "Snapshot",
-			"rdt:scope": "0x7f96f8291608",
+			"rdt:scope": "0x7ffa2a6f9d20",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T15.51.37EDT",
+			"rdt:timestamp": "2019-07-23T14.58.18EDT",
 			"rdt:location": ""
 		},
-		"rdt:d44": {
+		"rdt:d50": {
 			"rdt:name": "r",
 			"rdt:value": "20",
 			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
@@ -1500,7 +1696,7 @@
 			"rdt:timestamp": "",
 			"rdt:location": ""
 		},
-		"rdt:d45": {
+		"rdt:d51": {
 			"rdt:name": "fn() return",
 			"rdt:value": "20",
 			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
@@ -1511,7 +1707,7 @@
 			"rdt:timestamp": "",
 			"rdt:location": ""
 		},
-		"rdt:d46": {
+		"rdt:d52": {
 			"rdt:name": "fn10() return",
 			"rdt:value": "NULL",
 			"rdt:valType": "null",
@@ -1530,13 +1726,13 @@
 			"rdt:language": "R",
 			"rdt:langVersion": "R version 3.6.0 (2019-04-26)",
 			"rdt:script": "[DIR]/AssignOperators.R",
-			"rdt:scriptTimeStamp": "2019-07-19T15.47.32EDT",
-			"rdt:totalElapsedTime": "1.487",
+			"rdt:scriptTimeStamp": "2019-07-23T14.57.43EDT",
+			"rdt:totalElapsedTime": "1.579",
 			"rdt:sourcedScripts": "",
 			"rdt:sourcedScriptTimeStamps": "",
 			"rdt:workingDirectory": "[DIR]/rdt",
 			"rdt:provDirectory": "[DIR]/rdt/prov_AssignOperators",
-			"rdt:provTimestamp": "2019-07-19T15.51.35EDT",
+			"rdt:provTimestamp": "2019-07-23T14.58.16EDT",
 			"rdt:hashAlgorithm": "md5"
 		},
 
@@ -2010,6 +2206,58 @@
 		"rdt:pp99": {
 			"prov:informant": "rdt:p99",
 			"prov:informed": "rdt:p100"
+		},
+		"rdt:pp100": {
+			"prov:informant": "rdt:p100",
+			"prov:informed": "rdt:p101"
+		},
+		"rdt:pp101": {
+			"prov:informant": "rdt:p101",
+			"prov:informed": "rdt:p102"
+		},
+		"rdt:pp102": {
+			"prov:informant": "rdt:p102",
+			"prov:informed": "rdt:p103"
+		},
+		"rdt:pp103": {
+			"prov:informant": "rdt:p103",
+			"prov:informed": "rdt:p104"
+		},
+		"rdt:pp104": {
+			"prov:informant": "rdt:p104",
+			"prov:informed": "rdt:p105"
+		},
+		"rdt:pp105": {
+			"prov:informant": "rdt:p105",
+			"prov:informed": "rdt:p106"
+		},
+		"rdt:pp106": {
+			"prov:informant": "rdt:p106",
+			"prov:informed": "rdt:p107"
+		},
+		"rdt:pp107": {
+			"prov:informant": "rdt:p107",
+			"prov:informed": "rdt:p108"
+		},
+		"rdt:pp108": {
+			"prov:informant": "rdt:p108",
+			"prov:informed": "rdt:p109"
+		},
+		"rdt:pp109": {
+			"prov:informant": "rdt:p109",
+			"prov:informed": "rdt:p110"
+		},
+		"rdt:pp110": {
+			"prov:informant": "rdt:p110",
+			"prov:informed": "rdt:p111"
+		},
+		"rdt:pp111": {
+			"prov:informant": "rdt:p111",
+			"prov:informed": "rdt:p112"
+		},
+		"rdt:pp112": {
+			"prov:informant": "rdt:p112",
+			"prov:informed": "rdt:p113"
 		}
 	},
 
@@ -2167,7 +2415,7 @@
 			"prov:entity": "rdt:d38"
 		},
 		"rdt:pd39": {
-			"prov:activity": "rdt:p83",
+			"prov:activity": "rdt:p81",
 			"prov:entity": "rdt:d39"
 		},
 		"rdt:pd40": {
@@ -2175,28 +2423,52 @@
 			"prov:entity": "rdt:d40"
 		},
 		"rdt:pd41": {
-			"prov:activity": "rdt:p86",
+			"prov:activity": "rdt:p85",
 			"prov:entity": "rdt:d41"
 		},
 		"rdt:pd42": {
-			"prov:activity": "rdt:p89",
+			"prov:activity": "rdt:p87",
 			"prov:entity": "rdt:d42"
 		},
 		"rdt:pd43": {
-			"prov:activity": "rdt:p92",
+			"prov:activity": "rdt:p90",
 			"prov:entity": "rdt:d43"
 		},
 		"rdt:pd44": {
-			"prov:activity": "rdt:p95",
+			"prov:activity": "rdt:p93",
 			"prov:entity": "rdt:d44"
 		},
 		"rdt:pd45": {
-			"prov:activity": "rdt:p95",
+			"prov:activity": "rdt:p96",
 			"prov:entity": "rdt:d45"
 		},
 		"rdt:pd46": {
 			"prov:activity": "rdt:p97",
 			"prov:entity": "rdt:d46"
+		},
+		"rdt:pd47": {
+			"prov:activity": "rdt:p99",
+			"prov:entity": "rdt:d47"
+		},
+		"rdt:pd48": {
+			"prov:activity": "rdt:p102",
+			"prov:entity": "rdt:d48"
+		},
+		"rdt:pd49": {
+			"prov:activity": "rdt:p105",
+			"prov:entity": "rdt:d49"
+		},
+		"rdt:pd50": {
+			"prov:activity": "rdt:p108",
+			"prov:entity": "rdt:d50"
+		},
+		"rdt:pd51": {
+			"prov:activity": "rdt:p108",
+			"prov:entity": "rdt:d51"
+		},
+		"rdt:pd52": {
+			"prov:activity": "rdt:p110",
+			"prov:entity": "rdt:d52"
 		}
 	},
 
@@ -2314,36 +2586,52 @@
 			"prov:activity": "rdt:p79"
 		},
 		"rdt:dp29": {
-			"prov:entity": "rdt:d39",
-			"prov:activity": "rdt:p84"
-		},
-		"rdt:dp30": {
 			"prov:entity": "rdt:d40",
 			"prov:activity": "rdt:p85"
 		},
-		"rdt:dp31": {
-			"prov:entity": "rdt:d39",
+		"rdt:dp30": {
+			"prov:entity": "rdt:d41",
 			"prov:activity": "rdt:p86"
 		},
+		"rdt:dp31": {
+			"prov:entity": "rdt:d40",
+			"prov:activity": "rdt:p87"
+		},
 		"rdt:dp32": {
-			"prov:entity": "rdt:d39",
-			"prov:activity": "rdt:p88"
+			"prov:entity": "rdt:d43",
+			"prov:activity": "rdt:p92"
 		},
 		"rdt:dp33": {
-			"prov:entity": "rdt:d42",
-			"prov:activity": "rdt:p91"
-		},
-		"rdt:dp34": {
 			"prov:entity": "rdt:d45",
-			"prov:activity": "rdt:p96"
-		},
-		"rdt:dp35": {
-			"prov:entity": "rdt:d44",
 			"prov:activity": "rdt:p97"
 		},
-		"rdt:dp36": {
-			"prov:entity": "rdt:d44",
+		"rdt:dp34": {
+			"prov:entity": "rdt:d46",
+			"prov:activity": "rdt:p98"
+		},
+		"rdt:dp35": {
+			"prov:entity": "rdt:d45",
 			"prov:activity": "rdt:p99"
+		},
+		"rdt:dp36": {
+			"prov:entity": "rdt:d45",
+			"prov:activity": "rdt:p101"
+		},
+		"rdt:dp37": {
+			"prov:entity": "rdt:d48",
+			"prov:activity": "rdt:p104"
+		},
+		"rdt:dp38": {
+			"prov:entity": "rdt:d51",
+			"prov:activity": "rdt:p109"
+		},
+		"rdt:dp39": {
+			"prov:entity": "rdt:d50",
+			"prov:activity": "rdt:p110"
+		},
+		"rdt:dp40": {
+			"prov:entity": "rdt:d50",
+			"prov:activity": "rdt:p112"
 		}
 	}
 }

--- a/scriptTests/AssignOperators/rdt/expected_prov.json
+++ b/scriptTests/AssignOperators/rdt/expected_prov.json
@@ -16,7 +16,7 @@
 		"rdt:p1": {
 			"rdt:name": "AssignOperators.R",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.778",
+			"rdt:elapsedTime": "0.868",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -26,7 +26,7 @@
 		"rdt:p2": {
 			"rdt:name": "a = 1",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.197",
+			"rdt:elapsedTime": "0.195",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 11,
 			"rdt:startCol": 1,
@@ -36,7 +36,7 @@
 		"rdt:p3": {
 			"rdt:name": "stopifnot( a == 1 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.009",
+			"rdt:elapsedTime": "0.01",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 12,
 			"rdt:startCol": 1,
@@ -46,7 +46,7 @@
 		"rdt:p4": {
 			"rdt:name": "fn1 <- function()\n{\n  b = 2\n  stopifnot( b == 2 )\n}",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.006",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 16,
 			"rdt:startCol": 1,
@@ -56,7 +56,7 @@
 		"rdt:p5": {
 			"rdt:name": "fn1()",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.031",
+			"rdt:elapsedTime": "0.036",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -66,7 +66,7 @@
 		"rdt:p6": {
 			"rdt:name": "fn1",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.001",
+			"rdt:elapsedTime": "0.0",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -96,7 +96,7 @@
 		"rdt:p9": {
 			"rdt:name": "fn1()",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -116,7 +116,7 @@
 		"rdt:p11": {
 			"rdt:name": "fn2 <- function()\n{\n  d = 3\n  \n  fn <- function()\n  {\n\td ",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.004",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 28,
 			"rdt:startCol": 1,
@@ -126,7 +126,7 @@
 		"rdt:p12": {
 			"rdt:name": "fn2()",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.046",
+			"rdt:elapsedTime": "0.045",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -136,7 +136,7 @@
 		"rdt:p13": {
 			"rdt:name": "fn2",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.001",
+			"rdt:elapsedTime": "0.0",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -146,7 +146,7 @@
 		"rdt:p14": {
 			"rdt:name": "d = 3",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.001",
+			"rdt:elapsedTime": "0.002",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 30,
 			"rdt:startCol": 3,
@@ -166,7 +166,7 @@
 		"rdt:p16": {
 			"rdt:name": "fn()",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.013",
+			"rdt:elapsedTime": "0.012",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -176,7 +176,7 @@
 		"rdt:p17": {
 			"rdt:name": "fn",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.0",
+			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -186,7 +186,7 @@
 		"rdt:p18": {
 			"rdt:name": "d = 4",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.002",
+			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 34,
 			"rdt:startCol": 5,
@@ -206,7 +206,7 @@
 		"rdt:p20": {
 			"rdt:name": "stopifnot( d == 3 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.002",
+			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 38,
 			"rdt:startCol": 3,
@@ -216,7 +216,7 @@
 		"rdt:p21": {
 			"rdt:name": "fn2()",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.006",
+			"rdt:elapsedTime": "0.007",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -226,7 +226,7 @@
 		"rdt:p22": {
 			"rdt:name": "stopifnot( ! exists(\"d\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.0",
+			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 42,
 			"rdt:startCol": 1,
@@ -236,7 +236,7 @@
 		"rdt:p23": {
 			"rdt:name": "env1 <- new.env()",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.004",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 46,
 			"rdt:startCol": 1,
@@ -246,7 +246,7 @@
 		"rdt:p24": {
 			"rdt:name": "env1$e = 5",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 47,
 			"rdt:startCol": 1,
@@ -256,7 +256,7 @@
 		"rdt:p25": {
 			"rdt:name": "stopifnot( env1$e == 5 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.008",
+			"rdt:elapsedTime": "0.007",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 49,
 			"rdt:startCol": 1,
@@ -266,7 +266,7 @@
 		"rdt:p26": {
 			"rdt:name": "stopifnot( ! exists(\"e\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.006",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 50,
 			"rdt:startCol": 1,
@@ -286,7 +286,7 @@
 		"rdt:p28": {
 			"rdt:name": "env2$env <- new.env( parent = env2 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.004",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 55,
 			"rdt:startCol": 1,
@@ -296,7 +296,7 @@
 		"rdt:p29": {
 			"rdt:name": "env2$env$f = 6",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.007",
+			"rdt:elapsedTime": "0.009",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 56,
 			"rdt:startCol": 1,
@@ -306,7 +306,7 @@
 		"rdt:p30": {
 			"rdt:name": "stopifnot( env2$env$f == 6 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 58,
 			"rdt:startCol": 1,
@@ -326,7 +326,7 @@
 		"rdt:p32": {
 			"rdt:name": "stopifnot( ! exists(\"f\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 60,
 			"rdt:startCol": 1,
@@ -336,7 +336,7 @@
 		"rdt:p33": {
 			"rdt:name": "g <- 7",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 66,
 			"rdt:startCol": 1,
@@ -366,7 +366,7 @@
 		"rdt:p36": {
 			"rdt:name": "fn3()",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.011",
+			"rdt:elapsedTime": "0.012",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -396,7 +396,7 @@
 		"rdt:p39": {
 			"rdt:name": "stopifnot( h == 8 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 74,
 			"rdt:startCol": 3,
@@ -406,7 +406,7 @@
 		"rdt:p40": {
 			"rdt:name": "fn3()",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.009",
+			"rdt:elapsedTime": "0.01",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -446,7 +446,7 @@
 		"rdt:p44": {
 			"rdt:name": "fn4",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.0",
+			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -466,7 +466,7 @@
 		"rdt:p46": {
 			"rdt:name": "fn <- function()\n  {\n\ti <- 10\n  }",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.004",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 87,
 			"rdt:startCol": 3,
@@ -476,7 +476,7 @@
 		"rdt:p47": {
 			"rdt:name": "fn()",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.012",
+			"rdt:elapsedTime": "0.015",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -506,7 +506,7 @@
 		"rdt:p50": {
 			"rdt:name": "fn()",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.007",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -516,7 +516,7 @@
 		"rdt:p51": {
 			"rdt:name": "stopifnot( i == 9 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.002",
+			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 93,
 			"rdt:startCol": 3,
@@ -526,7 +526,7 @@
 		"rdt:p52": {
 			"rdt:name": "fn4()",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.006",
+			"rdt:elapsedTime": "0.007",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -556,7 +556,7 @@
 		"rdt:p55": {
 			"rdt:name": "env3$j <- 11",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 102,
 			"rdt:startCol": 1,
@@ -566,7 +566,7 @@
 		"rdt:p56": {
 			"rdt:name": "stopifnot( env3$j == 11 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.006",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 104,
 			"rdt:startCol": 1,
@@ -636,7 +636,7 @@
 		"rdt:p63": {
 			"rdt:name": "stopifnot( ! exists(\"k\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 115,
 			"rdt:startCol": 1,
@@ -666,7 +666,7 @@
 		"rdt:p66": {
 			"rdt:name": "fn5",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.0",
+			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -676,7 +676,7 @@
 		"rdt:p67": {
 			"rdt:name": "l <<- 13",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.002",
+			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 126,
 			"rdt:startCol": 3,
@@ -686,7 +686,7 @@
 		"rdt:p68": {
 			"rdt:name": "stopifnot( l == 13 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.007",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 127,
 			"rdt:startCol": 3,
@@ -726,7 +726,7 @@
 		"rdt:p72": {
 			"rdt:name": "fn6()",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.011",
+			"rdt:elapsedTime": "0.013",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -746,7 +746,7 @@
 		"rdt:p74": {
 			"rdt:name": "m <<- 14",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 138,
 			"rdt:startCol": 3,
@@ -756,7 +756,7 @@
 		"rdt:p75": {
 			"rdt:name": "fn6()",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.006",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -776,11 +776,11 @@
 		"rdt:p77": {
 			"rdt:name": "fn7 <- function()\n{\n  n <- 15\n  \n  fn7a <- function()\n  {\n  ",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.007",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 148,
+			"rdt:startLine": 152,
 			"rdt:startCol": 1,
-			"rdt:endLine": 160,
+			"rdt:endLine": 164,
 			"rdt:endCol": 1
 		},
 		"rdt:p78": {
@@ -796,7 +796,7 @@
 		"rdt:p79": {
 			"rdt:name": "fn7",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.0",
+			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -808,19 +808,19 @@
 			"rdt:type": "Operation",
 			"rdt:elapsedTime": "0.002",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 150,
+			"rdt:startLine": 154,
 			"rdt:startCol": 3,
-			"rdt:endLine": 150,
+			"rdt:endLine": 154,
 			"rdt:endCol": 9
 		},
 		"rdt:p81": {
 			"rdt:name": "fn7a <- function()\n  {\n\tn <<- 16\n\tstopifnot( n == 16 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.004",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 152,
+			"rdt:startLine": 156,
 			"rdt:startCol": 3,
-			"rdt:endLine": 156,
+			"rdt:endLine": 160,
 			"rdt:endCol": 3
 		},
 		"rdt:p82": {
@@ -848,25 +848,25 @@
 			"rdt:type": "Operation",
 			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 154,
+			"rdt:startLine": 158,
 			"rdt:startCol": 5,
-			"rdt:endLine": 154,
+			"rdt:endLine": 158,
 			"rdt:endCol": 12
 		},
 		"rdt:p85": {
 			"rdt:name": "stopifnot( n == 16 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.007",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 155,
+			"rdt:startLine": 159,
 			"rdt:startCol": 5,
-			"rdt:endLine": 155,
+			"rdt:endLine": 159,
 			"rdt:endCol": 24
 		},
 		"rdt:p86": {
 			"rdt:name": "fn7a()",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.006",
+			"rdt:elapsedTime": "0.007",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -876,17 +876,17 @@
 		"rdt:p87": {
 			"rdt:name": "stopifnot( n == 16 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.002",
+			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 159,
+			"rdt:startLine": 163,
 			"rdt:startCol": 3,
-			"rdt:endLine": 159,
+			"rdt:endLine": 163,
 			"rdt:endCol": 22
 		},
 		"rdt:p88": {
 			"rdt:name": "fn7()",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.007",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -896,27 +896,27 @@
 		"rdt:p89": {
 			"rdt:name": "stopifnot( ! exists(\"n\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.001",
+			"rdt:elapsedTime": "0.0",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 163,
+			"rdt:startLine": 167,
 			"rdt:startCol": 1,
-			"rdt:endLine": 163,
+			"rdt:endLine": 167,
 			"rdt:endCol": 26
 		},
 		"rdt:p90": {
 			"rdt:name": "fn9 <- function()\n{\n  fn <- function()\n  {\n\tp <<- 19\n\t",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 190,
+			"rdt:startLine": 194,
 			"rdt:startCol": 1,
-			"rdt:endLine": 200,
+			"rdt:endLine": 204,
 			"rdt:endCol": 1
 		},
 		"rdt:p91": {
 			"rdt:name": "fn9()",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.02",
+			"rdt:elapsedTime": "0.017",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -926,7 +926,7 @@
 		"rdt:p92": {
 			"rdt:name": "fn9",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.001",
+			"rdt:elapsedTime": "0.0",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -936,7 +936,7 @@
 		"rdt:p93": {
 			"rdt:name": "fn <- function() {\tp <<- 19\tstopifnot(p == 19)}",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.001",
+			"rdt:elapsedTime": "0.002",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -946,7 +946,7 @@
 		"rdt:p94": {
 			"rdt:name": "fn()",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.015",
+			"rdt:elapsedTime": "0.014",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -986,7 +986,7 @@
 		"rdt:p98": {
 			"rdt:name": "fn()",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.007",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -1018,9 +1018,9 @@
 			"rdt:type": "Operation",
 			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 203,
+			"rdt:startLine": 207,
 			"rdt:startCol": 1,
-			"rdt:endLine": 203,
+			"rdt:endLine": 207,
 			"rdt:endCol": 20
 		},
 		"rdt:p102": {
@@ -1028,9 +1028,9 @@
 			"rdt:type": "Operation",
 			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 210,
+			"rdt:startLine": 214,
 			"rdt:startCol": 1,
-			"rdt:endLine": 219,
+			"rdt:endLine": 223,
 			"rdt:endCol": 1
 		},
 		"rdt:p103": {
@@ -1066,7 +1066,7 @@
 		"rdt:p106": {
 			"rdt:name": "fn()",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.023",
+			"rdt:elapsedTime": "0.02",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -1076,7 +1076,7 @@
 		"rdt:p107": {
 			"rdt:name": "fn",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.0",
+			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -1086,7 +1086,7 @@
 		"rdt:p108": {
 			"rdt:name": "r <<- 20",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.002",
+			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -1096,7 +1096,7 @@
 		"rdt:p109": {
 			"rdt:name": "fn()",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.006",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -1106,7 +1106,7 @@
 		"rdt:p110": {
 			"rdt:name": "stopifnot(r == 20)",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.003",
+			"rdt:elapsedTime": "0.002",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -1128,9 +1128,9 @@
 			"rdt:type": "Operation",
 			"rdt:elapsedTime": "0.001",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 222,
+			"rdt:startLine": 226,
 			"rdt:startCol": 1,
-			"rdt:endLine": 222,
+			"rdt:endLine": 226,
 			"rdt:endCol": 20
 		},
 		"rdt:p113": {
@@ -1165,7 +1165,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.58.17EDT",
+			"rdt:timestamp": "2019-07-23T15.43.02EDT",
 			"rdt:location": ""
 		},
 		"rdt:d3": {
@@ -1173,7 +1173,7 @@
 			"rdt:value": "2",
 			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
 			"rdt:type": "Data",
-			"rdt:scope": "0x7ffa296f9ae8",
+			"rdt:scope": "0x7fda3ee95b68",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
 			"rdt:timestamp": "",
@@ -1198,7 +1198,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.58.17EDT",
+			"rdt:timestamp": "2019-07-23T15.43.02EDT",
 			"rdt:location": ""
 		},
 		"rdt:d6": {
@@ -1206,7 +1206,7 @@
 			"rdt:value": "3",
 			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
 			"rdt:type": "Data",
-			"rdt:scope": "0x7ffa25a4d958",
+			"rdt:scope": "0x7fda3f8e19d8",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
 			"rdt:timestamp": "",
@@ -1217,10 +1217,10 @@
 			"rdt:value": "data/7-fn.R",
 			"rdt:valType": "function",
 			"rdt:type": "Snapshot",
-			"rdt:scope": "0x7ffa25a4d958",
+			"rdt:scope": "0x7fda3f8e19d8",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.58.17EDT",
+			"rdt:timestamp": "2019-07-23T15.43.02EDT",
 			"rdt:location": ""
 		},
 		"rdt:d8": {
@@ -1228,7 +1228,7 @@
 			"rdt:value": "4",
 			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
 			"rdt:type": "Data",
-			"rdt:scope": "0x7ffa2bd06180",
+			"rdt:scope": "0x7fda427a1038",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
 			"rdt:timestamp": "",
@@ -1258,7 +1258,7 @@
 		},
 		"rdt:d11": {
 			"rdt:name": "env1",
-			"rdt:value": "<environment: 0x7ffa2a383540>",
+			"rdt:value": "<environment: 0x7fda43e520e8>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1269,7 +1269,7 @@
 		},
 		"rdt:d12": {
 			"rdt:name": "env1",
-			"rdt:value": "<environment: 0x7ffa2a383540>",
+			"rdt:value": "<environment: 0x7fda43e520e8>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1280,7 +1280,7 @@
 		},
 		"rdt:d13": {
 			"rdt:name": "env2",
-			"rdt:value": "<environment: 0x7ffa2a69a468>",
+			"rdt:value": "<environment: 0x7fda43b5fb98>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1291,7 +1291,7 @@
 		},
 		"rdt:d14": {
 			"rdt:name": "env2",
-			"rdt:value": "<environment: 0x7ffa2a69a468>",
+			"rdt:value": "<environment: 0x7fda43b5fb98>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1302,7 +1302,7 @@
 		},
 		"rdt:d15": {
 			"rdt:name": "env2",
-			"rdt:value": "<environment: 0x7ffa2a69a468>",
+			"rdt:value": "<environment: 0x7fda43b5fb98>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1330,7 +1330,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.58.18EDT",
+			"rdt:timestamp": "2019-07-23T15.43.02EDT",
 			"rdt:location": ""
 		},
 		"rdt:d18": {
@@ -1338,7 +1338,7 @@
 			"rdt:value": "8",
 			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
 			"rdt:type": "Data",
-			"rdt:scope": "0x7ffa2a2ea200",
+			"rdt:scope": "0x7fda44d94710",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
 			"rdt:timestamp": "",
@@ -1363,7 +1363,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.58.18EDT",
+			"rdt:timestamp": "2019-07-23T15.43.02EDT",
 			"rdt:location": ""
 		},
 		"rdt:d21": {
@@ -1371,7 +1371,7 @@
 			"rdt:value": "9",
 			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
 			"rdt:type": "Data",
-			"rdt:scope": "0x7ffa2a2203c0",
+			"rdt:scope": "0x7fda430bee28",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
 			"rdt:timestamp": "",
@@ -1382,10 +1382,10 @@
 			"rdt:value": "data/22-fn.R",
 			"rdt:valType": "function",
 			"rdt:type": "Snapshot",
-			"rdt:scope": "0x7ffa2a2203c0",
+			"rdt:scope": "0x7fda430bee28",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.58.18EDT",
+			"rdt:timestamp": "2019-07-23T15.43.02EDT",
 			"rdt:location": ""
 		},
 		"rdt:d23": {
@@ -1393,7 +1393,7 @@
 			"rdt:value": "10",
 			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
 			"rdt:type": "Data",
-			"rdt:scope": "0x7ffa2b8d5a48",
+			"rdt:scope": "0x7fda41b24dc8",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
 			"rdt:timestamp": "",
@@ -1423,7 +1423,7 @@
 		},
 		"rdt:d26": {
 			"rdt:name": "env3",
-			"rdt:value": "<environment: 0x7ffa2bf3ed20>",
+			"rdt:value": "<environment: 0x7fda44b9c390>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1434,7 +1434,7 @@
 		},
 		"rdt:d27": {
 			"rdt:name": "env3",
-			"rdt:value": "<environment: 0x7ffa2bf3ed20>",
+			"rdt:value": "<environment: 0x7fda44b9c390>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1445,7 +1445,7 @@
 		},
 		"rdt:d28": {
 			"rdt:name": "env4",
-			"rdt:value": "<environment: 0x7ffa2b491c30>",
+			"rdt:value": "<environment: 0x7fda441a19b8>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1456,7 +1456,7 @@
 		},
 		"rdt:d29": {
 			"rdt:name": "env4",
-			"rdt:value": "<environment: 0x7ffa2b491c30>",
+			"rdt:value": "<environment: 0x7fda441a19b8>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1467,7 +1467,7 @@
 		},
 		"rdt:d30": {
 			"rdt:name": "env4",
-			"rdt:value": "<environment: 0x7ffa2b491c30>",
+			"rdt:value": "<environment: 0x7fda441a19b8>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -1484,7 +1484,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.58.18EDT",
+			"rdt:timestamp": "2019-07-23T15.43.02EDT",
 			"rdt:location": ""
 		},
 		"rdt:d32": {
@@ -1517,7 +1517,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.58.18EDT",
+			"rdt:timestamp": "2019-07-23T15.43.02EDT",
 			"rdt:location": ""
 		},
 		"rdt:d35": {
@@ -1550,7 +1550,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.58.18EDT",
+			"rdt:timestamp": "2019-07-23T15.43.02EDT",
 			"rdt:location": ""
 		},
 		"rdt:d38": {
@@ -1558,7 +1558,7 @@
 			"rdt:value": "15",
 			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
 			"rdt:type": "Data",
-			"rdt:scope": "0x7ffa275eb1e8",
+			"rdt:scope": "0x7fda40c7a680",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
 			"rdt:timestamp": "",
@@ -1569,10 +1569,10 @@
 			"rdt:value": "data/39-fn7a.R",
 			"rdt:valType": "function",
 			"rdt:type": "Snapshot",
-			"rdt:scope": "0x7ffa275eb1e8",
+			"rdt:scope": "0x7fda40c7a680",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.58.18EDT",
+			"rdt:timestamp": "2019-07-23T15.43.02EDT",
 			"rdt:location": ""
 		},
 		"rdt:d40": {
@@ -1580,7 +1580,7 @@
 			"rdt:value": "16",
 			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
 			"rdt:type": "Data",
-			"rdt:scope": "0x7ffa275eb1e8",
+			"rdt:scope": "0x7fda40c7a680",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
 			"rdt:timestamp": "",
@@ -1616,7 +1616,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.58.18EDT",
+			"rdt:timestamp": "2019-07-23T15.43.02EDT",
 			"rdt:location": ""
 		},
 		"rdt:d44": {
@@ -1624,10 +1624,10 @@
 			"rdt:value": "data/44-fn.R",
 			"rdt:valType": "function",
 			"rdt:type": "Snapshot",
-			"rdt:scope": "0x7ffa2af80010",
+			"rdt:scope": "0x7fda42c9a3d0",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.58.18EDT",
+			"rdt:timestamp": "2019-07-23T15.43.02EDT",
 			"rdt:location": ""
 		},
 		"rdt:d45": {
@@ -1671,7 +1671,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.58.18EDT",
+			"rdt:timestamp": "2019-07-23T15.43.03EDT",
 			"rdt:location": ""
 		},
 		"rdt:d49": {
@@ -1679,10 +1679,10 @@
 			"rdt:value": "data/49-fn.R",
 			"rdt:valType": "function",
 			"rdt:type": "Snapshot",
-			"rdt:scope": "0x7ffa2a6f9d20",
+			"rdt:scope": "0x7fda44dbff68",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.58.18EDT",
+			"rdt:timestamp": "2019-07-23T15.43.03EDT",
 			"rdt:location": ""
 		},
 		"rdt:d50": {
@@ -1726,13 +1726,13 @@
 			"rdt:language": "R",
 			"rdt:langVersion": "R version 3.6.0 (2019-04-26)",
 			"rdt:script": "[DIR]/AssignOperators.R",
-			"rdt:scriptTimeStamp": "2019-07-23T14.57.43EDT",
-			"rdt:totalElapsedTime": "1.579",
+			"rdt:scriptTimeStamp": "2019-07-23T15.33.47EDT",
+			"rdt:totalElapsedTime": "1.67",
 			"rdt:sourcedScripts": "",
 			"rdt:sourcedScriptTimeStamps": "",
 			"rdt:workingDirectory": "[DIR]/rdt",
 			"rdt:provDirectory": "[DIR]/rdt/prov_AssignOperators",
-			"rdt:provTimestamp": "2019-07-23T14.58.16EDT",
+			"rdt:provTimestamp": "2019-07-23T15.43.01EDT",
 			"rdt:hashAlgorithm": "md5"
 		},
 

--- a/scriptTests/AssignOperators/rdt/expected_test.out
+++ b/scriptTests/AssignOperators/rdt/expected_test.out
@@ -5,4 +5,4 @@ Warning messages:
   Multiple functions defined with name fn .  Provenance about use of non-locals inside these functions may be incorrect.
 3: In .ddg.save.func.decl.info(.Object@parsed[[1]][[2]], .Object@parsed[[1]][[3]]) :
   Multiple functions defined with name fn .  Provenance about use of non-locals inside these functions may be incorrect.
-Execution Time = 2.054203
+Execution Time = 2.23389

--- a/scriptTests/AssignOperators/rdt/expected_test.out
+++ b/scriptTests/AssignOperators/rdt/expected_test.out
@@ -5,4 +5,4 @@ Warning messages:
   Multiple functions defined with name fn .  Provenance about use of non-locals inside these functions may be incorrect.
 3: In .ddg.save.func.decl.info(.Object@parsed[[1]][[2]], .Object@parsed[[1]][[3]]) :
   Multiple functions defined with name fn .  Provenance about use of non-locals inside these functions may be incorrect.
-Execution Time = 1.947434
+Execution Time = 2.054203

--- a/scriptTests/AssignOperators/rdtLite/expected_prov.json
+++ b/scriptTests/AssignOperators/rdtLite/expected_prov.json
@@ -16,7 +16,7 @@
 		"rdt:p1": {
 			"rdt:name": "AssignOperators.R",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.864",
+			"rdt:elapsedTime": "0.838",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -26,7 +26,7 @@
 		"rdt:p2": {
 			"rdt:name": "a = 1",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.115",
+			"rdt:elapsedTime": "0.124",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 11,
 			"rdt:startCol": 1,
@@ -36,7 +36,7 @@
 		"rdt:p3": {
 			"rdt:name": "stopifnot( a == 1 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.007",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 12,
 			"rdt:startCol": 1,
@@ -56,7 +56,7 @@
 		"rdt:p5": {
 			"rdt:name": "fn1()",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.015",
+			"rdt:elapsedTime": "0.014",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 22,
 			"rdt:startCol": 1,
@@ -66,7 +66,7 @@
 		"rdt:p6": {
 			"rdt:name": "stopifnot( ! exists(\"b\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 23,
 			"rdt:startCol": 1,
@@ -76,7 +76,7 @@
 		"rdt:p7": {
 			"rdt:name": "fn2 <- function()\n{\n  d = 3\n  \n  fn <- function()\n  {\n\td ",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 28,
 			"rdt:startCol": 1,
@@ -106,7 +106,7 @@
 		"rdt:p10": {
 			"rdt:name": "env1 <- new.env()",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.003",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 46,
 			"rdt:startCol": 1,
@@ -116,7 +116,7 @@
 		"rdt:p11": {
 			"rdt:name": "env1$e = 5",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 47,
 			"rdt:startCol": 1,
@@ -156,7 +156,7 @@
 		"rdt:p15": {
 			"rdt:name": "env2$env <- new.env( parent = env2 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.007",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 55,
 			"rdt:startCol": 1,
@@ -166,7 +166,7 @@
 		"rdt:p16": {
 			"rdt:name": "env2$env$f = 6",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.006",
+			"rdt:elapsedTime": "0.008",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 56,
 			"rdt:startCol": 1,
@@ -176,7 +176,7 @@
 		"rdt:p17": {
 			"rdt:name": "stopifnot( env2$env$f == 6 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 58,
 			"rdt:startCol": 1,
@@ -196,7 +196,7 @@
 		"rdt:p19": {
 			"rdt:name": "stopifnot( ! exists(\"f\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.003",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 60,
 			"rdt:startCol": 1,
@@ -216,7 +216,7 @@
 		"rdt:p21": {
 			"rdt:name": "stopifnot( g == 7 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.003",
+			"rdt:elapsedTime": "0.004",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 67,
 			"rdt:startCol": 1,
@@ -226,7 +226,7 @@
 		"rdt:p22": {
 			"rdt:name": "fn3 <- function()\n{\n  h <- 8\n  stopifnot( h == 8 )\n}",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.007",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 71,
 			"rdt:startCol": 1,
@@ -246,7 +246,7 @@
 		"rdt:p24": {
 			"rdt:name": "stopifnot( ! exists(\"h\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 78,
 			"rdt:startCol": 1,
@@ -256,7 +256,7 @@
 		"rdt:p25": {
 			"rdt:name": "fn4 <- function()\n{\n  i <- 9\n  \n  fn <- function()\n  {\n\ti",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 83,
 			"rdt:startCol": 1,
@@ -276,7 +276,7 @@
 		"rdt:p27": {
 			"rdt:name": "stopifnot( ! exists(\"i\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.006",
+			"rdt:elapsedTime": "0.004",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 97,
 			"rdt:startCol": 1,
@@ -326,7 +326,7 @@
 		"rdt:p32": {
 			"rdt:name": "env4 <- new.env()",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.003",
+			"rdt:elapsedTime": "0.004",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 109,
 			"rdt:startCol": 1,
@@ -336,7 +336,7 @@
 		"rdt:p33": {
 			"rdt:name": "env4$env <- new.env( parent = env4 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 110,
 			"rdt:startCol": 1,
@@ -376,7 +376,7 @@
 		"rdt:p37": {
 			"rdt:name": "stopifnot( ! exists(\"k\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.003",
+			"rdt:elapsedTime": "0.004",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 115,
 			"rdt:startCol": 1,
@@ -386,7 +386,7 @@
 		"rdt:p38": {
 			"rdt:name": "fn5 <- function()\n{\n  l <<- 13\n  stopifnot( l == 13 )\n}",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.003",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 124,
 			"rdt:startCol": 1,
@@ -416,7 +416,7 @@
 		"rdt:p41": {
 			"rdt:name": "fn6 <- function()\n{\n  m <<- 14\n}",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 136,
 			"rdt:startCol": 1,
@@ -436,7 +436,7 @@
 		"rdt:p43": {
 			"rdt:name": "stopifnot( m == 14 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.006",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 142,
 			"rdt:startCol": 1,
@@ -448,9 +448,9 @@
 			"rdt:type": "Operation",
 			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 148,
+			"rdt:startLine": 152,
 			"rdt:startCol": 1,
-			"rdt:endLine": 160,
+			"rdt:endLine": 164,
 			"rdt:endCol": 1
 		},
 		"rdt:p45": {
@@ -458,39 +458,39 @@
 			"rdt:type": "Operation",
 			"rdt:elapsedTime": "0.01",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 162,
+			"rdt:startLine": 166,
 			"rdt:startCol": 1,
-			"rdt:endLine": 162,
+			"rdt:endLine": 166,
 			"rdt:endCol": 5
 		},
 		"rdt:p46": {
 			"rdt:name": "stopifnot( ! exists(\"n\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 163,
+			"rdt:startLine": 167,
 			"rdt:startCol": 1,
-			"rdt:endLine": 163,
+			"rdt:endLine": 167,
 			"rdt:endCol": 26
 		},
 		"rdt:p47": {
 			"rdt:name": "fn9 <- function()\n{\n  fn <- function()\n  {\n\tp <<- 19\n\t",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.004",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 190,
+			"rdt:startLine": 194,
 			"rdt:startCol": 1,
-			"rdt:endLine": 200,
+			"rdt:endLine": 204,
 			"rdt:endCol": 1
 		},
 		"rdt:p48": {
 			"rdt:name": "fn9()",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.014",
+			"rdt:elapsedTime": "0.012",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 202,
+			"rdt:startLine": 206,
 			"rdt:startCol": 1,
-			"rdt:endLine": 202,
+			"rdt:endLine": 206,
 			"rdt:endCol": 5
 		},
 		"rdt:p49": {
@@ -498,19 +498,19 @@
 			"rdt:type": "Operation",
 			"rdt:elapsedTime": "0.008",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 203,
+			"rdt:startLine": 207,
 			"rdt:startCol": 1,
-			"rdt:endLine": 203,
+			"rdt:endLine": 207,
 			"rdt:endCol": 20
 		},
 		"rdt:p50": {
 			"rdt:name": "fn10 <- function()\n{\n  fn <- function()\n  {\n\tr <<- 20\n  }",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.004",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 210,
+			"rdt:startLine": 214,
 			"rdt:startCol": 1,
-			"rdt:endLine": 219,
+			"rdt:endLine": 223,
 			"rdt:endCol": 1
 		},
 		"rdt:p51": {
@@ -518,9 +518,9 @@
 			"rdt:type": "Operation",
 			"rdt:elapsedTime": "0.01",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 221,
+			"rdt:startLine": 225,
 			"rdt:startCol": 1,
-			"rdt:endLine": 221,
+			"rdt:endLine": 225,
 			"rdt:endCol": 6
 		},
 		"rdt:p52": {
@@ -528,15 +528,15 @@
 			"rdt:type": "Operation",
 			"rdt:elapsedTime": "0.008",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 222,
+			"rdt:startLine": 226,
 			"rdt:startCol": 1,
-			"rdt:endLine": 222,
+			"rdt:endLine": 226,
 			"rdt:endCol": 20
 		},
 		"rdt:p53": {
 			"rdt:name": "AssignOperators.R",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.007",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -565,7 +565,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.57.56EDT",
+			"rdt:timestamp": "2019-07-23T15.43.22EDT",
 			"rdt:location": ""
 		},
 		"rdt:d3": {
@@ -576,12 +576,12 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.57.56EDT",
+			"rdt:timestamp": "2019-07-23T15.43.22EDT",
 			"rdt:location": ""
 		},
 		"rdt:d4": {
 			"rdt:name": "env1",
-			"rdt:value": "<environment: 0x7fc60a1f17d8>",
+			"rdt:value": "<environment: 0x7fd568932ef0>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -592,7 +592,7 @@
 		},
 		"rdt:d5": {
 			"rdt:name": "env1",
-			"rdt:value": "<environment: 0x7fc60a1f17d8>",
+			"rdt:value": "<environment: 0x7fd568932ef0>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -603,7 +603,7 @@
 		},
 		"rdt:d6": {
 			"rdt:name": "env2",
-			"rdt:value": "<environment: 0x7fc609a6e2e0>",
+			"rdt:value": "<environment: 0x7fd5652db1f8>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -614,7 +614,7 @@
 		},
 		"rdt:d7": {
 			"rdt:name": "env2",
-			"rdt:value": "<environment: 0x7fc609a6e2e0>",
+			"rdt:value": "<environment: 0x7fd5652db1f8>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -625,7 +625,7 @@
 		},
 		"rdt:d8": {
 			"rdt:name": "env2",
-			"rdt:value": "<environment: 0x7fc609a6e2e0>",
+			"rdt:value": "<environment: 0x7fd5652db1f8>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -653,7 +653,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.57.56EDT",
+			"rdt:timestamp": "2019-07-23T15.43.23EDT",
 			"rdt:location": ""
 		},
 		"rdt:d11": {
@@ -664,12 +664,12 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.57.56EDT",
+			"rdt:timestamp": "2019-07-23T15.43.23EDT",
 			"rdt:location": ""
 		},
 		"rdt:d12": {
 			"rdt:name": "env3",
-			"rdt:value": "<environment: 0x7fc609deada8>",
+			"rdt:value": "<environment: 0x7fd566596b28>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -680,7 +680,7 @@
 		},
 		"rdt:d13": {
 			"rdt:name": "env3",
-			"rdt:value": "<environment: 0x7fc609deada8>",
+			"rdt:value": "<environment: 0x7fd566596b28>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -691,7 +691,7 @@
 		},
 		"rdt:d14": {
 			"rdt:name": "env4",
-			"rdt:value": "<environment: 0x7fc60819a278>",
+			"rdt:value": "<environment: 0x7fd567242ce8>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -702,7 +702,7 @@
 		},
 		"rdt:d15": {
 			"rdt:name": "env4",
-			"rdt:value": "<environment: 0x7fc60819a278>",
+			"rdt:value": "<environment: 0x7fd567242ce8>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -713,7 +713,7 @@
 		},
 		"rdt:d16": {
 			"rdt:name": "env4",
-			"rdt:value": "<environment: 0x7fc60819a278>",
+			"rdt:value": "<environment: 0x7fd567242ce8>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -730,7 +730,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.57.56EDT",
+			"rdt:timestamp": "2019-07-23T15.43.23EDT",
 			"rdt:location": ""
 		},
 		"rdt:d18": {
@@ -752,7 +752,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.57.56EDT",
+			"rdt:timestamp": "2019-07-23T15.43.23EDT",
 			"rdt:location": ""
 		},
 		"rdt:d20": {
@@ -774,7 +774,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.57.56EDT",
+			"rdt:timestamp": "2019-07-23T15.43.23EDT",
 			"rdt:location": ""
 		},
 		"rdt:d22": {
@@ -785,7 +785,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.57.56EDT",
+			"rdt:timestamp": "2019-07-23T15.43.23EDT",
 			"rdt:location": ""
 		},
 		"rdt:d23": {
@@ -807,7 +807,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-23T14.57.56EDT",
+			"rdt:timestamp": "2019-07-23T15.43.23EDT",
 			"rdt:location": ""
 		},
 		"rdt:d25": {
@@ -829,13 +829,13 @@
 			"rdt:language": "R",
 			"rdt:langVersion": "R version 3.6.0 (2019-04-26)",
 			"rdt:script": "[DIR]/AssignOperators.R",
-			"rdt:scriptTimeStamp": "2019-07-23T14.57.43EDT",
-			"rdt:totalElapsedTime": "1.328",
+			"rdt:scriptTimeStamp": "2019-07-23T15.33.47EDT",
+			"rdt:totalElapsedTime": "1.325",
 			"rdt:sourcedScripts": "",
 			"rdt:sourcedScriptTimeStamps": "",
 			"rdt:workingDirectory": "[DIR]/rdtLite",
 			"rdt:provDirectory": "[DIR]/rdtLite/prov_AssignOperators",
-			"rdt:provTimestamp": "2019-07-23T14.57.55EDT",
+			"rdt:provTimestamp": "2019-07-23T15.43.21EDT",
 			"rdt:hashAlgorithm": "md5"
 		},
 

--- a/scriptTests/AssignOperators/rdtLite/expected_prov.json
+++ b/scriptTests/AssignOperators/rdtLite/expected_prov.json
@@ -16,7 +16,7 @@
 		"rdt:p1": {
 			"rdt:name": "AssignOperators.R",
 			"rdt:type": "Start",
-			"rdt:elapsedTime": "0.829",
+			"rdt:elapsedTime": "0.864",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -26,7 +26,7 @@
 		"rdt:p2": {
 			"rdt:name": "a = 1",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.106",
+			"rdt:elapsedTime": "0.115",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 11,
 			"rdt:startCol": 1,
@@ -36,7 +36,7 @@
 		"rdt:p3": {
 			"rdt:name": "stopifnot( a == 1 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.006",
+			"rdt:elapsedTime": "0.007",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 12,
 			"rdt:startCol": 1,
@@ -56,7 +56,7 @@
 		"rdt:p5": {
 			"rdt:name": "fn1()",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.013",
+			"rdt:elapsedTime": "0.015",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 22,
 			"rdt:startCol": 1,
@@ -66,7 +66,7 @@
 		"rdt:p6": {
 			"rdt:name": "stopifnot( ! exists(\"b\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.004",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 23,
 			"rdt:startCol": 1,
@@ -76,7 +76,7 @@
 		"rdt:p7": {
 			"rdt:name": "fn2 <- function()\n{\n  d = 3\n  \n  fn <- function()\n  {\n\td ",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.004",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 28,
 			"rdt:startCol": 1,
@@ -86,7 +86,7 @@
 		"rdt:p8": {
 			"rdt:name": "fn2()",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.047",
+			"rdt:elapsedTime": "0.04",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 41,
 			"rdt:startCol": 1,
@@ -106,7 +106,7 @@
 		"rdt:p10": {
 			"rdt:name": "env1 <- new.env()",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.003",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 46,
 			"rdt:startCol": 1,
@@ -116,7 +116,7 @@
 		"rdt:p11": {
 			"rdt:name": "env1$e = 5",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 47,
 			"rdt:startCol": 1,
@@ -176,7 +176,7 @@
 		"rdt:p17": {
 			"rdt:name": "stopifnot( env2$env$f == 6 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.006",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 58,
 			"rdt:startCol": 1,
@@ -186,7 +186,7 @@
 		"rdt:p18": {
 			"rdt:name": "stopifnot( ! exists(\"env2$f\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.008",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 59,
 			"rdt:startCol": 1,
@@ -196,7 +196,7 @@
 		"rdt:p19": {
 			"rdt:name": "stopifnot( ! exists(\"f\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.003",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 60,
 			"rdt:startCol": 1,
@@ -206,7 +206,7 @@
 		"rdt:p20": {
 			"rdt:name": "g <- 7",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.006",
+			"rdt:elapsedTime": "0.004",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 66,
 			"rdt:startCol": 1,
@@ -236,7 +236,7 @@
 		"rdt:p23": {
 			"rdt:name": "fn3()",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.017",
+			"rdt:elapsedTime": "0.013",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 77,
 			"rdt:startCol": 1,
@@ -246,7 +246,7 @@
 		"rdt:p24": {
 			"rdt:name": "stopifnot( ! exists(\"h\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.004",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 78,
 			"rdt:startCol": 1,
@@ -266,7 +266,7 @@
 		"rdt:p26": {
 			"rdt:name": "fn4()",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.009",
+			"rdt:elapsedTime": "0.01",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 96,
 			"rdt:startCol": 1,
@@ -276,7 +276,7 @@
 		"rdt:p27": {
 			"rdt:name": "stopifnot( ! exists(\"i\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 97,
 			"rdt:startCol": 1,
@@ -286,7 +286,7 @@
 		"rdt:p28": {
 			"rdt:name": "env3 <- new.env()",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 101,
 			"rdt:startCol": 1,
@@ -326,7 +326,7 @@
 		"rdt:p32": {
 			"rdt:name": "env4 <- new.env()",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.003",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 109,
 			"rdt:startCol": 1,
@@ -346,7 +346,7 @@
 		"rdt:p34": {
 			"rdt:name": "env4$env$k <- 12",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.007",
+			"rdt:elapsedTime": "0.006",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 111,
 			"rdt:startCol": 1,
@@ -356,7 +356,7 @@
 		"rdt:p35": {
 			"rdt:name": "stopifnot( env4$env$k == 12 )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.008",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 113,
 			"rdt:startCol": 1,
@@ -366,7 +366,7 @@
 		"rdt:p36": {
 			"rdt:name": "stopifnot( ! exists(\"env4$k\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.008",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 114,
 			"rdt:startCol": 1,
@@ -376,7 +376,7 @@
 		"rdt:p37": {
 			"rdt:name": "stopifnot( ! exists(\"k\") )",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.003",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 115,
 			"rdt:startCol": 1,
@@ -396,7 +396,7 @@
 		"rdt:p39": {
 			"rdt:name": "fn5()",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.016",
+			"rdt:elapsedTime": "0.014",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 130,
 			"rdt:startCol": 1,
@@ -416,7 +416,7 @@
 		"rdt:p41": {
 			"rdt:name": "fn6 <- function()\n{\n  m <<- 14\n}",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.005",
+			"rdt:elapsedTime": "0.004",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 136,
 			"rdt:startCol": 1,
@@ -426,7 +426,7 @@
 		"rdt:p42": {
 			"rdt:name": "fn6()",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.014",
+			"rdt:elapsedTime": "0.013",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 141,
 			"rdt:startCol": 1,
@@ -444,69 +444,99 @@
 			"rdt:endCol": 20
 		},
 		"rdt:p44": {
-			"rdt:name": "fn9 <- function()\n{\n  fn <- function()\n  {\n\tp <<- 19\n\t",
+			"rdt:name": "fn7 <- function()\n{\n  n <- 15\n  \n  fn7a <- function()\n  {\n  ",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.006",
+			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 191,
+			"rdt:startLine": 148,
 			"rdt:startCol": 1,
-			"rdt:endLine": 201,
+			"rdt:endLine": 160,
 			"rdt:endCol": 1
 		},
 		"rdt:p45": {
+			"rdt:name": "fn7()",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": "0.01",
+			"rdt:scriptNum": 1,
+			"rdt:startLine": 162,
+			"rdt:startCol": 1,
+			"rdt:endLine": 162,
+			"rdt:endCol": 5
+		},
+		"rdt:p46": {
+			"rdt:name": "stopifnot( ! exists(\"n\") )",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": "0.004",
+			"rdt:scriptNum": 1,
+			"rdt:startLine": 163,
+			"rdt:startCol": 1,
+			"rdt:endLine": 163,
+			"rdt:endCol": 26
+		},
+		"rdt:p47": {
+			"rdt:name": "fn9 <- function()\n{\n  fn <- function()\n  {\n\tp <<- 19\n\t",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": "0.005",
+			"rdt:scriptNum": 1,
+			"rdt:startLine": 190,
+			"rdt:startCol": 1,
+			"rdt:endLine": 200,
+			"rdt:endCol": 1
+		},
+		"rdt:p48": {
 			"rdt:name": "fn9()",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.009",
+			"rdt:elapsedTime": "0.014",
+			"rdt:scriptNum": 1,
+			"rdt:startLine": 202,
+			"rdt:startCol": 1,
+			"rdt:endLine": 202,
+			"rdt:endCol": 5
+		},
+		"rdt:p49": {
+			"rdt:name": "stopifnot( p == 19 )",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": "0.008",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 203,
 			"rdt:startCol": 1,
 			"rdt:endLine": 203,
-			"rdt:endCol": 5
-		},
-		"rdt:p46": {
-			"rdt:name": "stopifnot( p == 19 )",
-			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.006",
-			"rdt:scriptNum": 1,
-			"rdt:startLine": 204,
-			"rdt:startCol": 1,
-			"rdt:endLine": 204,
 			"rdt:endCol": 20
 		},
-		"rdt:p47": {
+		"rdt:p50": {
 			"rdt:name": "fn10 <- function()\n{\n  fn <- function()\n  {\n\tr <<- 20\n  }",
 			"rdt:type": "Operation",
 			"rdt:elapsedTime": "0.005",
 			"rdt:scriptNum": 1,
-			"rdt:startLine": 211,
+			"rdt:startLine": 210,
 			"rdt:startCol": 1,
-			"rdt:endLine": 220,
+			"rdt:endLine": 219,
 			"rdt:endCol": 1
 		},
-		"rdt:p48": {
+		"rdt:p51": {
 			"rdt:name": "fn10()",
 			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.013",
+			"rdt:elapsedTime": "0.01",
+			"rdt:scriptNum": 1,
+			"rdt:startLine": 221,
+			"rdt:startCol": 1,
+			"rdt:endLine": 221,
+			"rdt:endCol": 6
+		},
+		"rdt:p52": {
+			"rdt:name": "stopifnot( r == 20 )",
+			"rdt:type": "Operation",
+			"rdt:elapsedTime": "0.008",
 			"rdt:scriptNum": 1,
 			"rdt:startLine": 222,
 			"rdt:startCol": 1,
 			"rdt:endLine": 222,
-			"rdt:endCol": 6
-		},
-		"rdt:p49": {
-			"rdt:name": "stopifnot( r == 20 )",
-			"rdt:type": "Operation",
-			"rdt:elapsedTime": "0.009",
-			"rdt:scriptNum": 1,
-			"rdt:startLine": 223,
-			"rdt:startCol": 1,
-			"rdt:endLine": 223,
 			"rdt:endCol": 20
 		},
-		"rdt:p50": {
+		"rdt:p53": {
 			"rdt:name": "AssignOperators.R",
 			"rdt:type": "Finish",
-			"rdt:elapsedTime": "0.004",
+			"rdt:elapsedTime": "0.007",
 			"rdt:scriptNum": "NA",
 			"rdt:startLine": "NA",
 			"rdt:startCol": "NA",
@@ -535,7 +565,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T16.22.30EDT",
+			"rdt:timestamp": "2019-07-23T14.57.56EDT",
 			"rdt:location": ""
 		},
 		"rdt:d3": {
@@ -546,12 +576,12 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T16.22.31EDT",
+			"rdt:timestamp": "2019-07-23T14.57.56EDT",
 			"rdt:location": ""
 		},
 		"rdt:d4": {
 			"rdt:name": "env1",
-			"rdt:value": "<environment: 0x7f8fe3cf6500>",
+			"rdt:value": "<environment: 0x7fc60a1f17d8>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -562,7 +592,7 @@
 		},
 		"rdt:d5": {
 			"rdt:name": "env1",
-			"rdt:value": "<environment: 0x7f8fe3cf6500>",
+			"rdt:value": "<environment: 0x7fc60a1f17d8>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -573,7 +603,7 @@
 		},
 		"rdt:d6": {
 			"rdt:name": "env2",
-			"rdt:value": "<environment: 0x7f8fe1d9de90>",
+			"rdt:value": "<environment: 0x7fc609a6e2e0>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -584,7 +614,7 @@
 		},
 		"rdt:d7": {
 			"rdt:name": "env2",
-			"rdt:value": "<environment: 0x7f8fe1d9de90>",
+			"rdt:value": "<environment: 0x7fc609a6e2e0>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -595,7 +625,7 @@
 		},
 		"rdt:d8": {
 			"rdt:name": "env2",
-			"rdt:value": "<environment: 0x7f8fe1d9de90>",
+			"rdt:value": "<environment: 0x7fc609a6e2e0>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -623,7 +653,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T16.22.31EDT",
+			"rdt:timestamp": "2019-07-23T14.57.56EDT",
 			"rdt:location": ""
 		},
 		"rdt:d11": {
@@ -634,12 +664,12 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T16.22.31EDT",
+			"rdt:timestamp": "2019-07-23T14.57.56EDT",
 			"rdt:location": ""
 		},
 		"rdt:d12": {
 			"rdt:name": "env3",
-			"rdt:value": "<environment: 0x7f8fe39f7370>",
+			"rdt:value": "<environment: 0x7fc609deada8>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -650,7 +680,7 @@
 		},
 		"rdt:d13": {
 			"rdt:name": "env3",
-			"rdt:value": "<environment: 0x7f8fe39f7370>",
+			"rdt:value": "<environment: 0x7fc609deada8>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -661,7 +691,7 @@
 		},
 		"rdt:d14": {
 			"rdt:name": "env4",
-			"rdt:value": "<environment: 0x7f8fe18985c0>",
+			"rdt:value": "<environment: 0x7fc60819a278>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -672,7 +702,7 @@
 		},
 		"rdt:d15": {
 			"rdt:name": "env4",
-			"rdt:value": "<environment: 0x7f8fe18985c0>",
+			"rdt:value": "<environment: 0x7fc60819a278>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -683,7 +713,7 @@
 		},
 		"rdt:d16": {
 			"rdt:name": "env4",
-			"rdt:value": "<environment: 0x7f8fe18985c0>",
+			"rdt:value": "<environment: 0x7fc60819a278>",
 			"rdt:valType": "environment",
 			"rdt:type": "Data",
 			"rdt:scope": "R_GlobalEnv",
@@ -700,7 +730,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T16.22.31EDT",
+			"rdt:timestamp": "2019-07-23T14.57.56EDT",
 			"rdt:location": ""
 		},
 		"rdt:d18": {
@@ -722,7 +752,7 @@
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T16.22.31EDT",
+			"rdt:timestamp": "2019-07-23T14.57.56EDT",
 			"rdt:location": ""
 		},
 		"rdt:d20": {
@@ -737,17 +767,28 @@
 			"rdt:location": ""
 		},
 		"rdt:d21": {
-			"rdt:name": "fn9",
-			"rdt:value": "data/21-fn9.R",
+			"rdt:name": "fn7",
+			"rdt:value": "data/21-fn7.R",
 			"rdt:valType": "function",
 			"rdt:type": "Snapshot",
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T16.22.31EDT",
+			"rdt:timestamp": "2019-07-23T14.57.56EDT",
 			"rdt:location": ""
 		},
 		"rdt:d22": {
+			"rdt:name": "fn9",
+			"rdt:value": "data/22-fn9.R",
+			"rdt:valType": "function",
+			"rdt:type": "Snapshot",
+			"rdt:scope": "R_GlobalEnv",
+			"rdt:fromEnv": false,
+			"rdt:hash": "",
+			"rdt:timestamp": "2019-07-23T14.57.56EDT",
+			"rdt:location": ""
+		},
+		"rdt:d23": {
 			"rdt:name": "p",
 			"rdt:value": "19",
 			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
@@ -758,18 +799,18 @@
 			"rdt:timestamp": "",
 			"rdt:location": ""
 		},
-		"rdt:d23": {
+		"rdt:d24": {
 			"rdt:name": "fn10",
-			"rdt:value": "data/23-fn10.R",
+			"rdt:value": "data/24-fn10.R",
 			"rdt:valType": "function",
 			"rdt:type": "Snapshot",
 			"rdt:scope": "R_GlobalEnv",
 			"rdt:fromEnv": false,
 			"rdt:hash": "",
-			"rdt:timestamp": "2019-07-19T16.22.31EDT",
+			"rdt:timestamp": "2019-07-23T14.57.56EDT",
 			"rdt:location": ""
 		},
-		"rdt:d24": {
+		"rdt:d25": {
 			"rdt:name": "r",
 			"rdt:value": "20",
 			"rdt:valType": "{\"container\":\"vector\", \"dimension\":[1], \"type\":[\"numeric\"]}",
@@ -788,13 +829,13 @@
 			"rdt:language": "R",
 			"rdt:langVersion": "R version 3.6.0 (2019-04-26)",
 			"rdt:script": "[DIR]/AssignOperators.R",
-			"rdt:scriptTimeStamp": "2019-07-19T15.47.32EDT",
-			"rdt:totalElapsedTime": "1.277",
+			"rdt:scriptTimeStamp": "2019-07-23T14.57.43EDT",
+			"rdt:totalElapsedTime": "1.328",
 			"rdt:sourcedScripts": "",
 			"rdt:sourcedScriptTimeStamps": "",
 			"rdt:workingDirectory": "[DIR]/rdtLite",
 			"rdt:provDirectory": "[DIR]/rdtLite/prov_AssignOperators",
-			"rdt:provTimestamp": "2019-07-19T16.22.30EDT",
+			"rdt:provTimestamp": "2019-07-23T14.57.55EDT",
 			"rdt:hashAlgorithm": "md5"
 		},
 
@@ -1068,6 +1109,18 @@
 		"rdt:pp49": {
 			"prov:informant": "rdt:p49",
 			"prov:informed": "rdt:p50"
+		},
+		"rdt:pp50": {
+			"prov:informant": "rdt:p50",
+			"prov:informed": "rdt:p51"
+		},
+		"rdt:pp51": {
+			"prov:informant": "rdt:p51",
+			"prov:informed": "rdt:p52"
+		},
+		"rdt:pp52": {
+			"prov:informant": "rdt:p52",
+			"prov:informed": "rdt:p53"
 		}
 	},
 
@@ -1157,16 +1210,20 @@
 			"prov:entity": "rdt:d21"
 		},
 		"rdt:pd22": {
-			"prov:activity": "rdt:p45",
+			"prov:activity": "rdt:p47",
 			"prov:entity": "rdt:d22"
 		},
 		"rdt:pd23": {
-			"prov:activity": "rdt:p47",
+			"prov:activity": "rdt:p48",
 			"prov:entity": "rdt:d23"
 		},
 		"rdt:pd24": {
-			"prov:activity": "rdt:p48",
+			"prov:activity": "rdt:p50",
 			"prov:entity": "rdt:d24"
+		},
+		"rdt:pd25": {
+			"prov:activity": "rdt:p51",
+			"prov:entity": "rdt:d25"
 		}
 	},
 
@@ -1257,15 +1314,19 @@
 		},
 		"rdt:dp22": {
 			"prov:entity": "rdt:d22",
-			"prov:activity": "rdt:p46"
+			"prov:activity": "rdt:p48"
 		},
 		"rdt:dp23": {
 			"prov:entity": "rdt:d23",
-			"prov:activity": "rdt:p48"
+			"prov:activity": "rdt:p49"
 		},
 		"rdt:dp24": {
 			"prov:entity": "rdt:d24",
-			"prov:activity": "rdt:p49"
+			"prov:activity": "rdt:p51"
+		},
+		"rdt:dp25": {
+			"prov:entity": "rdt:d25",
+			"prov:activity": "rdt:p52"
 		}
 	}
 }

--- a/scriptTests/AssignOperators/rdtLite/expected_test.out
+++ b/scriptTests/AssignOperators/rdtLite/expected_test.out
@@ -1,1 +1,1 @@
-Execution Time = 1.674648
+Execution Time = 1.805813

--- a/scriptTests/AssignOperators/rdtLite/expected_test.out
+++ b/scriptTests/AssignOperators/rdtLite/expected_test.out
@@ -1,1 +1,1 @@
-Execution Time = 1.805813
+Execution Time = 1.718233


### PR DESCRIPTION
When an inner function does a non-local, non-global assignment, rdtLite
no longer attempts to create a data node for it.  Trying to do so
resulted in an error since the variable could not be found in the global
scope, which is the only scope rdtLite has access to.

Also, rdt creates the correct nodes and edges in this case.