### PR TITLE
Added output of ant and java versions when tests are run

### DIFF
--- a/tests.xml
+++ b/tests.xml
@@ -2662,9 +2662,18 @@
 	
 	<!-- helper target -->
 	<target name="run-tests">
+	    <!-- Display version info -->
+		<echo message = "ant version is ${ant.version}" />
+		<echo message = "java version is ${ant.java.version}" />
+	
 		<antcall target="ProvJson"/>
 		<antcall target="quick-test"/>
 		<antcall target="script-tests"/>
+		
+		<!-- Repeat version info at the end so it is easy to find. -->
+		<echo message = "ant version is ${ant.version}" />
+		<echo message = "java version is ${ant.java.version}" />
+		
 	</target>
 	
 	<!-- ========== End: Targets for Running All Tests ========== -->	


### PR DESCRIPTION
This happens for test-travis and test-all but not individual tests, to
avoid seeing the version number repeatedly output with each test.