### PR TITLE
Fixed typo in .travis-rdtLite.yml

### DIFF
--- a/.travis-rdtLite.yml
+++ b/.travis-rdtLite.yml
@@ -20,7 +20,7 @@ before-install:
   - .libPaths ("/home/travis/R/Library")
 
 install: 
-  - Rscript -e 'install.packages (c("devtools", "roxygen2", "knitr", "rmakdown", "jsonvalidate", "XML", "testthat", "gplots", "ggplot2", "stringi", "RCurl", "provSummarizeR", "provViz"))'
+  - Rscript -e 'install.packages (c("devtools", "roxygen2", "knitr", "rmarkdown", "jsonvalidate", "XML", "testthat", "gplots", "ggplot2", "stringi", "RCurl", "provSummarizeR", "provViz"))'
   - Rscript -e 'print (installed.packages())'
 
 before_script:


### PR DESCRIPTION
rmarkdown was misspelled, preventing the tests from running on Travis.