### PR TITLE
Fixed bug when creating warning nodes

### DIFF
--- a/R/RDataTracker_core.R
+++ b/R/RDataTracker_core.R
@@ -922,7 +922,7 @@
   callStr <-
       if (is.null (w$call)) ""
       else paste ("In ", utils::head (deparse(w$call)), ": ")
-  warningMessage <- paste (callStr, w$message)
+  warningMessage <- paste (callStr[1], w$message)
 
   # Create the warning node
   .ddg.insert.error.message(warningMessage, "warning.msg", doWarn = FALSE)


### PR DESCRIPTION
If the call string to include in the warning was more than one line
long, there was a warning while creating the warning node.

Fixes issue #604 