### PR TITLE
Changed ggplot2 from a required package to a suggested package

### DIFF
--- a/DESCRIPTION_rdt
+++ b/DESCRIPTION_rdt
@@ -47,7 +47,6 @@ BugReports: https://github.com/End-to-end-provenance/RDataTracker/issues
 Imports: 
   curl,
   digest,
-  ggplot2,
   grDevices,
   gtools,
   jsonlite, 
@@ -64,6 +63,7 @@ Imports:
   utils,
   XML
 Suggests: 
+  ggplot2,
   testthat
 VignetteBuilder: knitr
 RoxygenNote: 6.0.1

--- a/DESCRIPTION_rdtLite
+++ b/DESCRIPTION_rdtLite
@@ -42,7 +42,6 @@ BugReports: https://github.com/End-to-end-provenance/rdtLite/issues
 Imports:
   curl,
   digest,
-  ggplot2,
   grDevices, 
   gtools,
   jsonlite,
@@ -58,6 +57,7 @@ Imports:
   utils,
   XML
 Suggests: 
+  ggplot2,
   roxygen2, 
   testthat
 VignetteBuilder: knitr

--- a/R/RDataTracker_core.R
+++ b/R/RDataTracker_core.R
@@ -573,7 +573,7 @@
     #print(paste(".ddg.create.data.set.edges.for.cmd: var = ", var))
     
     # Check for a new ggplot that was not assigned to a variable
-    if (.ddg.get ("ddg.ggplot.created")) {
+    if ("ggplot2" %in% .ddg.get("ddg.installed.package.names") && .ddg.get ("ddg.ggplot.created")) {
       if (var == "") {      
         # Add a data node for the plot and link it in.
         # Set ddg.last.ggplot to the name of this node


### PR DESCRIPTION
We only use it for tracing the files it produces.  If a user does not
otherwise need ggplot2, they should have to install it.  It now checks
if it is installed before setting up the tracing.